### PR TITLE
Run tests by invoking the migrator as a subprocess

### DIFF
--- a/lib/runner.dart
+++ b/lib/runner.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:path/path.dart' as p;
+import 'package:term_glyph/term_glyph.dart' as glyph;
 
 import 'src/migrators/module.dart';
 
@@ -17,15 +18,18 @@ class MigratorRunner extends CommandRunner<Map<Uri, String>> {
 
   MigratorRunner()
       : super("sass_migrator", "Migrates stylesheets to new Sass versions.") {
-    argParser.addFlag('migrate-deps',
-        abbr: 'd', help: 'Migrate dependencies in addition to entrypoints.');
-    argParser.addFlag('dry-run',
-        abbr: 'n',
-        help: 'Show which files would be migrated but make no changes.');
-    // TODO(jathak): Make this flag print a diff instead.
-    argParser.addFlag('verbose',
-        abbr: 'v',
-        help: 'Print text of migrated files when running with --dry-run.');
+    argParser
+      ..addFlag('migrate-deps',
+          abbr: 'd', help: 'Migrate dependencies in addition to entrypoints.')
+      ..addFlag('dry-run',
+          abbr: 'n',
+          help: 'Show which files would be migrated but make no changes.')
+      ..addFlag('unicode',
+          help: 'Whether to use Unicode characters for messages.')
+      // TODO(jathak): Make this flag print a diff instead.
+      ..addFlag('verbose',
+          abbr: 'v',
+          help: 'Print text of migrated files when running with --dry-run.');
     addCommand(ModuleMigrator());
   }
 
@@ -33,6 +37,10 @@ class MigratorRunner extends CommandRunner<Map<Uri, String>> {
   /// `--dry-run` is passed.
   Future execute(Iterable<String> args) async {
     var argResults = parse(args);
+    if (argResults['unicode'] != null) {
+      glyph.ascii = !(argResults['unicode'] as bool);
+    }
+
     var migrated = await runCommand(argResults);
     if (migrated == null) return;
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -18,18 +18,18 @@ export 'package:sass/src/utils.dart' show normalizedMap, normalizedSet;
 
 import 'patch.dart';
 
+/// A filesystem importer that loads Sass files relative to the current working
+/// directory.
+final _filesystemImporter = FilesystemImporter('.');
+
 /// Returns the canonical version of [url].
-Uri canonicalize(Uri url) {
-  var importer = FilesystemImporter(Directory.current.path);
-  return importer.canonicalize(url);
-}
+Uri canonicalize(Uri url) => _filesystemImporter.canonicalize(url);
 
 /// Parses the file at [url] into a stylesheet.
 Stylesheet parseStylesheet(Uri url) {
-  var importer = FilesystemImporter(Directory.current.path);
-  url = importer.canonicalize(url);
-  var result = importer.load(url);
-  return Stylesheet.parse(result.contents, result.syntax, url: url);
+  var canonicalUrl = _filesystemImporter.canonicalize(url);
+  var result = _filesystemImporter.load(canonicalUrl);
+  return Stylesheet.parse(result.contents, result.syntax, url: canonicalUrl);
 }
 
 /// Returns the default namespace for a use rule with [path].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,3 +15,4 @@ dev_dependencies:
   term_glyph: "^1.1.0"
   test: ">=0.12.29 <2.0.0"
   test_descriptor: "^1.1.1"
+  test_process: "^1.0.0"

--- a/test/migrator_utils.dart
+++ b/test/migrator_utils.dart
@@ -54,8 +54,14 @@ Future<void> _testHrx(File hrxFile, String migrator) async {
   expect(process.stdout, emitsDone);
   await process.shouldExit(0);
 
-  await Future.wait(files.output.keys
-      .map((path) => d.file(path, files.output[path]).validate()));
+  await Future.wait([
+    Future.wait(files.output.keys
+        .map((path) => d.file(path, files.output[path]).validate())),
+    // Ensure that the migrator *doesn't* migrate files it's not supposed to.
+    Future.wait(files.input.keys
+        .where((path) => !files.output.containsKey(path))
+        .map((path) => d.file(path, files.input[path]).validate()))
+  ]);
 }
 
 class _HrxTestFiles {

--- a/test/migrators/module/namespace_get_function.hrx
+++ b/test/migrators/module/namespace_get_function.hrx
@@ -42,12 +42,12 @@ $x: "increment";
 $fn5: meta.get-function($x);
 
 <==> log.txt
-line 9, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+line 9, column 20 of entrypoint.scss: WARNING - get-function call may require $module parameter
   ,
 9 | $fn4: get-function("incre" + "ment");
   |                    ^^^^^^^^^^^^^^^^
   '
-line 12, column 20 of $TEST_DIR/entrypoint.scss: WARNING - get-function call may require $module parameter
+line 12, column 20 of entrypoint.scss: WARNING - get-function call may require $module parameter
    ,
 12 | $fn5: get-function($x);
    |                    ^^


### PR DESCRIPTION
This will make it easier to test a Node.js executable, and avoids
needing a bunch of dependency injection.