### PR TITLE
Add cast to fix type error in division migrator

### DIFF
--- a/lib/src/migrators/division.dart
+++ b/lib/src/migrators/division.dart
@@ -217,7 +217,7 @@ class _DivisionMigrationVisitor extends MigrationVisitor {
       // Remove `#{` and `}`
       addPatch(patchDelete(node.span, end: 2));
       addPatch(patchDelete(node.span, start: node.span.length - 1));
-      node.text.contents.first.accept(this);
+      (node.text.contents.first as Expression).accept(this);
     } else {
       node.accept(this);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: "^1.5.1"
   charcode: "^1.1.0"
-  sass: "^1.18.0"
+  sass: "^1.20.3"
   source_span: "^1.4.0"
   meta: ">=0.9.0 <2.0.0"
   path: "^1.6.0"


### PR DESCRIPTION
This broke because sass/dart-sass#709 changed the type of `Interpolation.contents` from `List<dynamic>` to `List<Object>`.