### PR TITLE
Emit warnings to stderr

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -6,4 +6,4 @@
 
 // These libraries don't expose *exactly* the same API, but they overlap in all
 // the cases we care about.
-export 'dart:io' if (dart.library.js) 'package:node_io/node_io.dart';
+export 'dart:io' if (dart.library.js) 'io/node.dart';

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -1,0 +1,20 @@
+// Copyright 2019 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:js/js.dart';
+
+export 'package:node_io/node_io.dart';
+
+// ignore: missing_js_lib_annotation
+@JS("process.stderr.write")
+external _writeToStderr(String text);
+
+class Stderr {
+  void write(object) => _writeToStderr(object.toString());
+  void writeln([object]) => _writeToStderr("${object ?? ''}\n");
+}
+
+final stderr = Stderr();

--- a/lib/src/migrators/division.dart
+++ b/lib/src/migrators/division.dart
@@ -196,7 +196,7 @@ class _DivisionMigrationVisitor extends MigrationVisitor {
           expectsNumericResult: true);
       return true;
     } else {
-      warn("Could not determine whether this is division", node.span);
+      emitWarning("Could not determine whether this is division", node.span);
       super.visitBinaryOperationExpression(node);
       return false;
     }

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -149,7 +149,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
           node.arguments.named['name'] ?? node.arguments.positional.first;
       if (nameArgument is! StringExpression ||
           (nameArgument as StringExpression).text.asPlain == null) {
-        warn("get-function call may require \$module parameter",
+        emitWarning("get-function call may require \$module parameter",
             nameArgument.span);
         return;
       }
@@ -203,7 +203,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
               existingArgName: _findArgNameSpan(arg));
           name = 'adjust';
         } else {
-          warn("Could not migrate malformed '$name' call", node.span);
+          emitWarning("Could not migrate malformed '$name' call", node.span);
           return;
         }
       }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -60,8 +60,8 @@ Patch patchDelete(FileSpan span, {int start = 0, int end}) {
 }
 
 /// Emits a warning with [message] and [context];
-void warn(String message, FileSpan context) {
-  print(context.message("WARNING - $message"));
+void emitWarning(String message, FileSpan context) {
+  stderr.writeln(context.message("WARNING - $message"));
 }
 
 /// An exception thrown by a migrator.

--- a/test/migrator_utils.dart
+++ b/test/migrator_utils.dart
@@ -96,11 +96,17 @@ Future<void> _testHrx(File hrxFile, String migrator, {bool node: false}) async {
       workingDirectory: d.sandbox,
       description: "migrator");
 
-  if (files.expectedLog != null) {
+  if (files.expectedStdout != null) {
     expect(process.stdout,
-        emitsInOrder(files.expectedLog.trimRight().split("\n")));
+        emitsInOrder(files.expectedStdout.trimRight().split("\n")));
   }
   expect(process.stdout, emitsDone);
+
+  if (files.expectedStderr != null) {
+    expect(process.stderr,
+        emitsInOrder(files.expectedStderr.trimRight().split("\n")));
+  }
+  expect(process.stderr, emitsDone);
   await process.shouldExit(0);
 
   await Future.wait([
@@ -117,7 +123,8 @@ class _HrxTestFiles {
   Map<String, String> input = {};
   Map<String, String> output = {};
   List<String> arguments = [];
-  String expectedLog;
+  String expectedStdout;
+  String expectedStderr;
 
   _HrxTestFiles(String hrxText) {
     // TODO(jathak): Replace this with an actual HRX parser.
@@ -142,8 +149,10 @@ class _HrxTestFiles {
       input[filename.substring(6)] = contents;
     } else if (filename.startsWith("output/")) {
       output[filename.substring(7)] = contents;
-    } else if (filename == "log.txt") {
-      expectedLog = contents;
+    } else if (filename == "stdout.log") {
+      expectedStdout = contents;
+    } else if (filename == "stderr.log") {
+      expectedStderr = contents;
     } else if (filename == "arguments") {
       arguments = contents.trim().split(" ");
     }

--- a/test/migrators/division/maybe_division_pessimistic.hrx
+++ b/test/migrators/division/maybe_division_pessimistic.hrx
@@ -10,7 +10,7 @@ a {
   f: 3 / $x;
 }
 
-<==> log.txt
+<==> stderr.log
 line 2, column 7 of entrypoint.scss: WARNING - Could not determine whether this is division
   ,
 2 |   b: (3 / $x) + 4;
@@ -36,4 +36,6 @@ line 6, column 6 of entrypoint.scss: WARNING - Could not determine whether this 
 6 |   f: 3 / $x;
   |      ^^^^^^
   '
+
+<==> stdout.log
 Nothing to migrate!

--- a/test/migrators/division/never_division.hrx
+++ b/test/migrators/division/never_division.hrx
@@ -8,5 +8,5 @@
   g: rgb(10 20 30 / 0.5);
 }
 
-<==> log.txt
+<==> stdout.log
 Nothing to migrate!

--- a/test/migrators/module/convert_color_adjust.hrx
+++ b/test/migrators/module/convert_color_adjust.hrx
@@ -21,7 +21,7 @@ $g: color.adjust(#37f, $alpha: -20%);
 $h: color.adjust(rgba(10, 20, 30, 0.5), $alpha: -10%);
 $i: lighten(pink, 5%, 10%); // too many arguments
 
-<==> log.txt
+<==> stderr.log
 line 9, column 5 of entrypoint.scss: WARNING - Could not migrate malformed 'lighten' call
   ,
 9 | $i: lighten(pink, 5%, 10%); // too many arguments

--- a/test/migrators/module/namespace_get_function.hrx
+++ b/test/migrators/module/namespace_get_function.hrx
@@ -41,7 +41,7 @@ $fn4: meta.get-function("incre" + "ment");
 $x: "increment";
 $fn5: meta.get-function($x);
 
-<==> log.txt
+<==> stderr.log
 line 9, column 20 of entrypoint.scss: WARNING - get-function call may require $module parameter
   ,
 9 | $fn4: get-function("incre" + "ment");


### PR DESCRIPTION
Resolves #14.

This also renames the `warn` function in `lib/src/utils.dart` to `emitWarning` to avoid conflicting with the `warn` function now exposed by Sass.