### PR TITLE
Warn instead of crashing for bad URLs

### DIFF
--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -36,12 +36,12 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
   final bool migrateDependencies;
 
   /// Map of missing dependency URLs to the spans that import/use them.
-  UnmodifiableMapView<Uri, FileSpan> get missingDependencies =>
+  Map<Uri, FileSpan> get missingDependencies =>
       UnmodifiableMapView(_missingDependencies);
   final _missingDependencies = <Uri, FileSpan>{};
 
   /// The patches to be applied to the stylesheet being migrated.
-  UnmodifiableListView<Patch> get patches => UnmodifiableListView(_patches);
+  List<Patch> get patches => UnmodifiableListView(_patches);
   List<Patch> _patches;
 
   MigrationVisitor({this.migrateDependencies = true});
@@ -79,7 +79,7 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
     if (stylesheet != null) {
       visitStylesheet(stylesheet);
     } else {
-      _missingDependencies[url] = context;
+      _missingDependencies.putIfAbsent(url, () => context);
     }
   }
 

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -49,7 +49,10 @@ abstract class Migrator extends Command<Map<Uri, String>> {
     var allMigrated = Map<Uri, String>();
     for (var entrypoint in argResults.rest) {
       var canonicalUrl = canonicalize(Uri.parse(entrypoint));
-      if (canonicalUrl == null) continue;
+      if (canonicalUrl == null) {
+        throw MigrationException(
+            "Error: Could not find Sass file at '$entrypoint'.");
+      }
       var migrated = migrateFile(canonicalUrl);
       for (var file in migrated.keys) {
         if (allMigrated.containsKey(file) &&

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -29,6 +29,11 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   bool get migrateDependencies => globalResults['migrate-deps'] as bool;
 
   /// Map of missing dependency URLs to the spans that import/use them.
+  ///
+  /// Subclasses should add any missing dependencies to this when they are
+  /// encountered during migration. If using [MigrationVisitor], all items in
+  /// its `missingDependencies` property should be added to this after calling
+  /// `run`.
   final missingDependencies = <Uri, FileSpan>{};
 
   /// Runs this migrator on [entrypoint] (and its dependencies, if the

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -45,7 +45,9 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   Map<Uri, String> run() {
     var allMigrated = Map<Uri, String>();
     for (var entrypoint in argResults.rest) {
-      var migrated = migrateFile(canonicalize(Uri.parse(entrypoint)));
+      var canonicalUrl = canonicalize(Uri.parse(entrypoint));
+      if (canonicalUrl == null) continue;
+      var migrated = migrateFile(canonicalUrl);
       for (var file in migrated.keys) {
         if (allMigrated.containsKey(file) &&
             migrated[file] != allMigrated[file]) {

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -26,6 +26,9 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   /// If true, dependencies will be migrated in addition to the entrypoints.
   bool get migrateDependencies => globalResults['migrate-deps'] as bool;
 
+  /// List of warnings for dependency URLs that could not be resolved.
+  final missingDependencies = <String>[];
+
   /// Runs this migrator on [entrypoint] (and its dependencies, if the
   /// --migrate-deps flag is passed).
   ///
@@ -55,6 +58,16 @@ abstract class Migrator extends Command<Map<Uri, String>> {
               "$file is migrated in more than one way by these entrypoints.");
         }
         allMigrated[file] = migrated[file];
+      }
+    }
+    if (missingDependencies.isNotEmpty) {
+      var count = missingDependencies.length;
+      emitWarning(
+          "$count dependenc${count == 1 ? 'y' : 'ies'} could not be found.");
+      if (globalResults['verbose'] as bool) {
+        for (var warning in missingDependencies) {
+          print('  $warning');
+        }
       }
     }
     return allMigrated;

--- a/lib/src/migrators/division.dart
+++ b/lib/src/migrators/division.dart
@@ -38,7 +38,7 @@ More info: https://sass-lang.com/d/slash-div""";
   @override
   Map<Uri, String> migrateFile(Uri entrypoint) =>
       _DivisionMigrationVisitor(this.isPessimistic, migrateDependencies)
-          .run(entrypoint);
+          .run(entrypoint, missingDependencies);
 }
 
 class _DivisionMigrationVisitor extends MigrationVisitor {
@@ -199,8 +199,7 @@ class _DivisionMigrationVisitor extends MigrationVisitor {
           expectsNumericResult: true);
       return true;
     } else {
-      emitWarning("Could not determine whether this is division",
-          context: node.span);
+      emitWarning("Could not determine whether this is division", node.span);
       super.visitBinaryOperationExpression(node);
       return false;
     }

--- a/lib/src/migrators/division.dart
+++ b/lib/src/migrators/division.dart
@@ -199,7 +199,8 @@ class _DivisionMigrationVisitor extends MigrationVisitor {
           expectsNumericResult: true);
       return true;
     } else {
-      emitWarning("Could not determine whether this is division", node.span);
+      emitWarning("Could not determine whether this is division",
+          context: node.span);
       super.visitBinaryOperationExpression(node);
       return false;
     }

--- a/lib/src/migrators/division.dart
+++ b/lib/src/migrators/division.dart
@@ -36,9 +36,13 @@ More info: https://sass-lang.com/d/slash-div""";
   bool get isPessimistic => argResults['pessimistic'] as bool;
 
   @override
-  Map<Uri, String> migrateFile(Uri entrypoint) =>
-      _DivisionMigrationVisitor(this.isPessimistic, migrateDependencies)
-          .run(entrypoint, missingDependencies);
+  Map<Uri, String> migrateFile(Uri entrypoint) {
+    var visitor =
+        _DivisionMigrationVisitor(this.isPessimistic, migrateDependencies);
+    var result = visitor.run(entrypoint);
+    missingDependencies.addAll(visitor.missingDependencies);
+    return result;
+  }
 }
 
 class _DivisionMigrationVisitor extends MigrationVisitor {

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -153,7 +153,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       if (nameArgument is! StringExpression ||
           (nameArgument as StringExpression).text.asPlain == null) {
         emitWarning("get-function call may require \$module parameter",
-            nameArgument.span);
+            context: nameArgument.span);
         return;
       }
       var fnName = nameArgument as StringExpression;
@@ -206,7 +206,8 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
               existingArgName: _findArgNameSpan(arg));
           name = 'adjust';
         } else {
-          emitWarning("Could not migrate malformed '$name' call", node.span);
+          emitWarning("Could not migrate malformed '$name' call",
+              context: node.span);
           return;
         }
       }
@@ -270,7 +271,10 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
 
     var oldConfiguredVariables = _configuredVariables;
     _configuredVariables = Set();
-    visitDependency(Uri.parse(import.url), _currentUrl);
+    if (!visitDependency(Uri.parse(import.url), _currentUrl,
+        context: import.span)) {
+      return;
+    }
     _namespaces[_lastUrl] = namespaceForPath(import.url);
 
     // Pass the variables that were configured by the importing file to `with`,

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -78,7 +78,7 @@ class MigratorRunner extends CommandRunner<Map<Uri, String>> {
       for (var url in migrated.keys) {
         assert(url.scheme == null || url.scheme == "file",
             "$url is not a file path.");
-        if (argResults['verbose']) print("Mirating ${p.prettyUri(url)}");
+        if (argResults['verbose']) print("Migrating ${p.prettyUri(url)}");
         File(url.toFilePath()).writeAsStringSync(migrated[url]);
       }
     }

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -13,6 +13,7 @@ import 'package:term_glyph/term_glyph.dart' as glyph;
 import 'io.dart';
 import 'migrators/division.dart';
 import 'migrators/module.dart';
+import 'utils.dart';
 
 /// A command runner that runs a migrator based on provided arguments.
 class MigratorRunner extends CommandRunner<Map<Uri, String>> {
@@ -55,8 +56,14 @@ class MigratorRunner extends CommandRunner<Map<Uri, String>> {
     if (argResults.wasParsed('unicode')) {
       glyph.ascii = !(argResults['unicode'] as bool);
     }
-
-    var migrated = await runCommand(argResults);
+    Map<Uri, String> migrated;
+    try {
+      migrated = await runCommand(argResults);
+    } on MigrationException catch (e) {
+      print(e);
+      print('Migration failed!');
+      return;
+    }
     if (migrated == null) return;
 
     if (migrated.isEmpty) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -4,7 +4,6 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 
 // The sass package's API is not necessarily stable. It is being imported with
@@ -22,18 +21,11 @@ import 'patch.dart';
 final _filesystemImporter = FilesystemImporter('.');
 
 /// Returns the canonical version of [url].
-Uri canonicalize(Uri url, {FileSpan context}) {
-  var canonicalUrl = url == null ? null : _filesystemImporter.canonicalize(url);
-  if (canonicalUrl == null) {
-    emitWarning("Could not find Sass file at '${p.prettyUri(url)}'.",
-        context: context);
-  }
-  return canonicalUrl;
-}
+Uri canonicalize(Uri url) => _filesystemImporter.canonicalize(url);
 
 /// Parses the file at [url] into a stylesheet.
-Stylesheet parseStylesheet(Uri url, {FileSpan context}) {
-  var canonicalUrl = canonicalize(url, context: context);
+Stylesheet parseStylesheet(Uri url) {
+  var canonicalUrl = canonicalize(url);
   if (canonicalUrl == null) return null;
   var result = _filesystemImporter.load(canonicalUrl);
   return Stylesheet.parse(result.contents, result.syntax, url: canonicalUrl);
@@ -68,7 +60,7 @@ Patch patchDelete(FileSpan span, {int start = 0, int end}) {
 }
 
 /// Emits a warning with [message] and optionally [context];
-void emitWarning(String message, {FileSpan context}) {
+void emitWarning(String message, [FileSpan context]) {
   if (context == null) {
     print("WARNING - $message");
   } else {

--- a/test/migrators/division/bad_paths.hrx
+++ b/test/migrators/division/bad_paths.hrx
@@ -7,4 +7,6 @@
 
 <==> log.txt
 WARNING - 2 dependencies could not be found.
+  does_not_exist @entrypoint.scss:1
+  does_not_exist2 @entrypoint.scss:2
 Nothing to migrate!

--- a/test/migrators/division/bad_paths.hrx
+++ b/test/migrators/division/bad_paths.hrx
@@ -1,0 +1,13 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "does_not_exist";
+
+<==> log.txt
+line 1, column 9 of entrypoint.scss: WARNING - Could not find Sass file at 'does_not_exist'.
+  ,
+1 | @import "does_not_exist";
+  |         ^^^^^^^^^^^^^^^^
+  '
+Nothing to migrate!

--- a/test/migrators/division/bad_paths_verbose.hrx
+++ b/test/migrators/division/bad_paths_verbose.hrx
@@ -1,5 +1,5 @@
 <==> arguments
---migrate-deps
+--migrate-deps --verbose
 
 <==> input/entrypoint.scss
 @import "does_not_exist";
@@ -7,4 +7,6 @@
 
 <==> log.txt
 WARNING - 2 dependencies could not be found.
+  does_not_exist @entrypoint.scss:1
+  does_not_exist2 @entrypoint.scss:2
 Nothing to migrate!

--- a/test/migrators/division/bad_paths_verbose.hrx
+++ b/test/migrators/division/bad_paths_verbose.hrx
@@ -6,7 +6,14 @@
 @import "does_not_exist2";
 
 <==> log.txt
-WARNING - 2 dependencies could not be found.
-  does_not_exist @entrypoint.scss:1
-  does_not_exist2 @entrypoint.scss:2
+line 1, column 9 of entrypoint.scss: WARNING - Could not find Sass file at 'does_not_exist'.
+  ,
+1 | @import "does_not_exist";
+  |         ^^^^^^^^^^^^^^^^
+  '
+line 2, column 9 of entrypoint.scss: WARNING - Could not find Sass file at 'does_not_exist2'.
+  ,
+2 | @import "does_not_exist2";
+  |         ^^^^^^^^^^^^^^^^^
+  '
 Nothing to migrate!

--- a/test/migrators/module/bad_paths.hrx
+++ b/test/migrators/module/bad_paths.hrx
@@ -1,0 +1,11 @@
+<==> input/entrypoint.scss
+@import "does_not_exist";
+@import "does_not_exist2";
+
+<==> log.txt
+line 1, column 9 of entrypoint.scss: Error: Could not find Sass file at 'does_not_exist'.
+  ,
+1 | @import "does_not_exist";
+  |         ^^^^^^^^^^^^^^^^
+  '
+Migration failed!


### PR DESCRIPTION
Fixes #57. Fixes #59.

The migrator will now print a warning for any URL that doesn't exist (both entrypoints and dependencies).