### PR TITLE
Add tests for indented syntax

### DIFF
--- a/test/migrators/module/namespace_mixin.hrx
+++ b/test/migrators/module/namespace_mixin.hrx
@@ -1,6 +1,9 @@
 <==> arguments
 --migrate-deps
 
+<==> README.md
+This test should be kept in sync with namespace_mixin_indented.hrx.
+
 <==> input/entrypoint.scss
 @import "library";
 a {

--- a/test/migrators/module/namespace_mixin_indented.hrx
+++ b/test/migrators/module/namespace_mixin_indented.hrx
@@ -4,6 +4,9 @@
 <==> README.md
 This test should be kept in sync with namespace_mixin.hrx.
 
+This test is duplicated for the indented syntax since it includes the shorthand
+mixin syntax that's not present in the SCSS syntax.
+
 <==> input/entrypoint.sass
 @import "library"
 a

--- a/test/migrators/module/namespace_mixin_indented.hrx
+++ b/test/migrators/module/namespace_mixin_indented.hrx
@@ -1,0 +1,21 @@
+<==> arguments
+--migrate-deps
+
+<==> README.md
+This test should be kept in sync with namespace_mixin.hrx.
+
+<==> input/entrypoint.sass
+@import "library"
+a
+  +helper
+  @include helper
+
+<==> input/_library.sass
+=helper
+  display: block
+
+<==> output/entrypoint.sass
+@use "library"
+a
+  +library.helper
+  @include library.helper

--- a/test/migrators/module/unprefix.hrx
+++ b/test/migrators/module/unprefix.hrx
@@ -1,6 +1,9 @@
 <==> arguments
 --remove-prefix=lib-
 
+<==> README.md
+This test should be kept in sync with unprefix_indented.hrx.
+
 <==> input/entrypoint.scss
 $lib-a: 5;
 $lib_b: $lib-a + 2;

--- a/test/migrators/module/unprefix_indented.hrx
+++ b/test/migrators/module/unprefix_indented.hrx
@@ -1,0 +1,35 @@
+<==> arguments
+--remove-prefix=lib-
+
+<==> README.md
+This test should be kept in sync with unprefix.hrx.
+
+<==> input/entrypoint.sass
+$lib-a: 5
+$lib_b: $lib-a + 2
+
+@function lib-fn($lib-local)
+  @return $lib-local
+
+$result: lib-fn(0)
+
+=lib-mixin
+  lib-property: lib-value
+
+lib-selector
+  +lib-mixin
+
+<==> output/entrypoint.sass
+$a: 5
+$b: $a + 2
+
+@function fn($lib-local)
+  @return $lib-local
+
+$result: fn(0)
+
+=mixin
+  lib-property: lib-value
+
+lib-selector
+  +mixin

--- a/test/migrators/module/unprefix_indented.hrx
+++ b/test/migrators/module/unprefix_indented.hrx
@@ -4,6 +4,10 @@
 <==> README.md
 This test should be kept in sync with unprefix.hrx.
 
+This test is duplicated for the indented syntax since it tests that removing
+prefixes works even for the shorthand mixin syntax and it includes sufficient
+other functionality to test the basics of the syntax.
+
 <==> input/entrypoint.sass
 $lib-a: 5
 $lib_b: $lib-a + 2


### PR DESCRIPTION
Resolves #5.

This adds copies of the unprefix and namespace_mixin tests that use the indented syntax and the shorthand `+`/`=` syntax for mixins.

I initially thought about making indented syntax copies of all tests, but that felt redundant, as these two tests should have enough to test the basics of the indented syntax and the one special case I could find (the mixin shorthand syntax).

Are there any other things particular to the indented syntax that would be good to add tests for or do these seem fine?