### PR TITLE
Require dependencies in the preamble rather than through JS-interop

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   args: "^1.5.1"


### PR DESCRIPTION
sass/dart-sass#727 changed the way it depended on the Node fs module, breaking the migrator's use of it.

This changes the JS build script for the migrator to match the new behavior in the sass package.