### PR TITLE
Add flag for forwarding members from entrypoint

### DIFF
--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -12,15 +12,15 @@ import 'package:args/args.dart';
 import 'package:sass/src/ast/sass.dart';
 
 import 'package:path/path.dart' as p;
-import 'package:sass_migrator/src/migrators/module/forward_type.dart';
 import 'package:source_span/source_span.dart';
 
-import 'package:sass_migrator/src/migration_visitor.dart';
-import 'package:sass_migrator/src/migrator.dart';
-import 'package:sass_migrator/src/patch.dart';
-import 'package:sass_migrator/src/utils.dart';
+import '../migration_visitor.dart';
+import '../migrator.dart';
+import '../patch.dart';
+import '../utils.dart';
 
 import 'module/built_in_functions.dart';
+import 'module/forward_type.dart';
 import 'module/scope.dart';
 import 'module/unreferencable_type.dart';
 

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -31,7 +31,19 @@ class ModuleMigrator extends Migrator {
   @override
   final argParser = ArgParser()
     ..addOption('remove-prefix',
-        abbr: 'p', help: 'Removes the provided prefix from members.');
+        abbr: 'p', help: 'Removes the provided prefix from members.')
+    ..addOption('forward',
+        allowed: ['all', 'none', 'prefixed'],
+        allowedHelp: {
+          'none': "Doesn't forward any members.",
+          'prefixed':
+              'Forwards members that start with the prefix specified for '
+                  '--remove-prefix.',
+          'all': 'Forwards all members.'
+        },
+        defaultsTo: 'none',
+        help: 'Specifies which members from dependencies to forward from the '
+            'entrypoint.');
 
   // Hide this until it's finished and the module system is launched.
   final hidden = true;
@@ -42,9 +54,15 @@ class ModuleMigrator extends Migrator {
   /// If [migrateDependencies] is false, the migrator will still be run on
   /// dependencies, but they will be excluded from the resulting map.
   Map<Uri, String> migrateFile(Uri entrypoint) {
+    if (argResults['forward'] == 'prefixed' &&
+        argResults['remove-prefix'] == null) {
+      throw MigrationException(
+          'Error: Must provide --remove-prefix when --forward=prefixed');
+    }
     var migrated = _ModuleMigrationVisitor(
             prefixToRemove:
-                (argResults['remove-prefix'] as String)?.replaceAll('_', '-'))
+                (argResults['remove-prefix'] as String)?.replaceAll('_', '-'),
+            forwardOption: argResults['forward'] as String)
         .run(entrypoint);
     if (!migrateDependencies) {
       migrated.removeWhere((url, contents) => url != entrypoint);
@@ -96,12 +114,15 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   /// should be removed.
   final String prefixToRemove;
 
+  /// The value of the --forward flag, either 'none', 'all', or 'prefixed'.
+  final String forwardOption;
+
   /// Constructs a new module migration visitor.
   ///
   /// Note: We always set [migratedDependencies] to true since the module
   /// migrator needs to always run on dependencies. The `migrateFile` method of
   /// the module migrator will filter out the dependencies' migration results.
-  _ModuleMigrationVisitor({this.prefixToRemove})
+  _ModuleMigrationVisitor({this.prefixToRemove, this.forwardOption})
       : super(migrateDependencies: true);
 
   /// Returns a semicolon unless the current stylesheet uses the indented
@@ -117,7 +138,86 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (results == null) return null;
     var uses = _additionalUseRules
         .map((use) => '@use "$use"$_semicolonIfNotIndented\n');
-    return uses.join() + results;
+    return _getEntrypointForwards() + uses.join() + results;
+  }
+
+  /// Returns whether an member of [name] should be forwarded in the entrypoint.
+  ///
+  /// [name] should be the original name of that member, even if it started with
+  /// [prefixToRemove].
+  bool _shouldForward(String name) {
+    switch (forwardOption) {
+      case 'all':
+        return true;
+      case 'none':
+        return false;
+      case 'prefixed':
+        return name.startsWith(prefixToRemove);
+      default:
+        throw StateError('--forward should not allow invalid values');
+    }
+  }
+
+  /// If the current stylesheet is the entrypoint, return a string of @forward
+  /// rules to forward all members for which [_shouldForward] returns true.
+  String _getEntrypointForwards() {
+    if (!_scope.isGlobal) {
+      throw StateError('Must be called from root of stylesheet');
+    }
+    if (_upstreamStylesheets.isNotEmpty) return '';
+
+    // Divide all global members from dependencies into sets based on whether
+    // they should be forwarded or not.
+    var shown = <Uri, Set<String>>{};
+    var hidden = <Uri, Set<String>>{};
+    categorizeMember(Uri url, String originalName, String newName) {
+      if (url == _currentUrl) return;
+      if (_shouldForward(originalName)) {
+        shown[url] ??= {};
+        shown[url].add(newName);
+      } else {
+        hidden[url] ??= {};
+        hidden[url].add(newName);
+      }
+    }
+
+    for (var entry in _scope.variables.entries) {
+      if (entry.value is! VariableDeclaration) continue;
+      categorizeMember(entry.value.span.sourceUrl,
+          (entry.value as VariableDeclaration).name, '\$${entry.key}');
+    }
+    for (var entry in _scope.mixins.entries) {
+      categorizeMember(entry.value.span.sourceUrl, entry.value.name, entry.key);
+    }
+    for (var entry in _scope.functions.entries) {
+      categorizeMember(entry.value.span.sourceUrl, entry.value.name, entry.key);
+    }
+
+    // Create a @forward rule for each dependency that has members that should
+    // be forwarded.
+    var forwards = <String>[];
+    for (var url in shown.keys) {
+      var shownCount = shown[url].length;
+      var hiddenCount = hidden[url]?.length ?? 0;
+      var forward = '@forward "${_absoluteUriToDependency(url)}"';
+
+      // When not all members from a dependency should be forwarded, determine
+      // whether to use a `show` clause or a `hide` clause based on the number
+      // of members in each set.
+      if (hiddenCount > 0) {
+        if (shownCount <= hiddenCount) {
+          var shownMembers = shown[url].toList()..sort();
+          forward += ' show ${shownMembers.join(", ")}';
+        } else {
+          var hiddenMembers = hidden[url].toList()..sort();
+          forward += ' hide ${hiddenMembers.join(", ")}';
+        }
+      }
+      forward += '$_semicolonIfNotIndented\n';
+      forwards.add(forward);
+    }
+    forwards.sort();
+    return forwards.join('');
   }
 
   /// Visits the stylesheet at [dependency], resolved relative to [source].
@@ -578,15 +678,21 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (node.span.sourceUrl == _currentUrl) return null;
     if (!_namespaces.containsKey(node.span.sourceUrl)) {
       /// Add new use rule for indirect dependency
-      var relativePath = p.relative(node.span.sourceUrl.path,
-          from: p.dirname(_currentUrl.path));
-      var basename = p.basenameWithoutExtension(relativePath);
-      if (basename.startsWith('_')) basename = basename.substring(1);
-      var simplePath = p.relative(p.join(p.dirname(relativePath), basename));
+      var simplePath = _absoluteUriToDependency(node.span.sourceUrl);
       _additionalUseRules.add(simplePath);
       _namespaces[node.span.sourceUrl] = namespaceForPath(simplePath);
     }
     return _namespaces[node.span.sourceUrl];
+  }
+
+  /// Converts an absolute URI for a stylesheet into the simplest string that
+  /// could be used to depend on that stylesheet from the current one in a use,
+  /// forward, or import rule.
+  String _absoluteUriToDependency(Uri uri) {
+    var relativePath = p.relative(uri.path, from: p.dirname(_currentUrl.path));
+    var basename = p.basenameWithoutExtension(relativePath);
+    if (basename.startsWith('_')) basename = basename.substring(1);
+    return p.relative(p.join(p.dirname(relativePath), basename));
   }
 
   /// Disallows @use after @at-root rules.

--- a/lib/src/migrators/module/forward_type.dart
+++ b/lib/src/migrators/module/forward_type.dart
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:meta/meta.dart';
+
+/// An enum of values for the --forward option.
+@sealed
+class ForwardType {
+  /// Forward all members from the entrypoint
+  static const all = ForwardType._('all');
+
+  /// Forward all members from the entrypoint
+  static const none = ForwardType._('none');
+
+  /// Forward all members from the entrypoint
+  static const prefixed = ForwardType._('prefixed');
+
+  /// Identifier for this value.
+  final String id;
+
+  const ForwardType._(this.id);
+
+  factory ForwardType(String option) {
+    switch (option) {
+      case 'all':
+        return ForwardType.all;
+      case 'none':
+        return ForwardType.none;
+      case 'prefixed':
+        return ForwardType.prefixed;
+      default:
+        throw StateError('Invalid value "${option}" for --forward option.');
+    }
+  }
+}

--- a/test/migrators/module/forward_all.hrx
+++ b/test/migrators/module/forward_all.hrx
@@ -1,0 +1,12 @@
+<==> arguments
+--migrate-deps --forward=all
+
+<==> input/entrypoint.scss
+@import "library";
+
+<==> input/_library.scss
+$variable: blue;
+
+<==> output/entrypoint.scss
+@forward "library";
+@use "library";

--- a/test/migrators/module/forward_all_no_members.hrx
+++ b/test/migrators/module/forward_all_no_members.hrx
@@ -1,0 +1,13 @@
+<==> arguments
+--migrate-deps --forward=all
+
+<==> input/entrypoint.scss
+@import "library";
+
+<==> input/_library.scss
+a {
+  b: c;
+}
+
+<==> output/entrypoint.scss
+@use "library";

--- a/test/migrators/module/forward_prefixed.hrx
+++ b/test/migrators/module/forward_prefixed.hrx
@@ -1,0 +1,53 @@
+<==> arguments
+--migrate-deps --remove-prefix=lib- --forward=prefixed
+
+<==> input/entrypoint.scss
+@import "lib1";
+@import "lib2";
+@import "lib3";
+
+<==> input/_lib1.scss
+@function lib-fn() {
+  @return 0;
+}
+
+@mixin lib-mixin {
+  a: b;
+}
+
+<==> input/_lib2.scss
+$lib-a: 1;
+$lib-b: 2;
+$c: 3;
+
+<==> input/_lib3.scss
+$lib-d: 4;
+$e: 5;
+$f: 6;
+
+<==> output/entrypoint.scss
+@forward "lib1";
+@forward "lib2" hide $c;
+@forward "lib3" show $d;
+@use "lib1";
+@use "lib2";
+@use "lib3";
+
+<==> output/_lib1.scss
+@function fn() {
+  @return 0;
+}
+
+@mixin mixin {
+  a: b;
+}
+
+<==> output/_lib2.scss
+$a: 1;
+$b: 2;
+$c: 3;
+
+<==> output/_lib3.scss
+$d: 4;
+$e: 5;
+$f: 6;

--- a/test/migrators/module/forward_prefixed.hrx
+++ b/test/migrators/module/forward_prefixed.hrx
@@ -4,7 +4,6 @@
 <==> input/entrypoint.scss
 @import "lib1";
 @import "lib2";
-@import "lib3";
 
 <==> input/_lib1.scss
 @function lib-fn() {
@@ -20,18 +19,15 @@ $lib-a: 1;
 $lib-b: 2;
 $c: 3;
 
-<==> input/_lib3.scss
-$lib-d: 4;
-$e: 5;
-$f: 6;
+@mixin not-prefixed {
+  a: b;
+}
 
 <==> output/entrypoint.scss
 @forward "lib1";
-@forward "lib2" hide $c;
-@forward "lib3" show $d;
+@forward "lib2" hide $c, not-prefixed;
 @use "lib1";
 @use "lib2";
-@use "lib3";
 
 <==> output/_lib1.scss
 @function fn() {
@@ -47,7 +43,6 @@ $a: 1;
 $b: 2;
 $c: 3;
 
-<==> output/_lib3.scss
-$d: 4;
-$e: 5;
-$f: 6;
+@mixin not-prefixed {
+  a: b;
+}


### PR DESCRIPTION
Resolves #47.

Adds a new flag `--forward` which can be `none` (default), `all`, or `prefixed`.

If `--forward=all`, all global members from dependencies will be forwarded from the entrypoint.

If `--forward=prefixed`, only members that were previously prefixed with the value of `--remove-prefix` will be forwarded.