### PR TITLE
Add flag to remove leading dashes and underscores

### DIFF
--- a/test/migrators/module/forward_pseudoprivate.hrx
+++ b/test/migrators/module/forward_pseudoprivate.hrx
@@ -1,0 +1,25 @@
+<==> arguments
+--migrate-deps --forward=all --dash-is-library-private
+
+<==> input/entrypoint.scss
+@import "dependency";
+
+a {
+  color: $_pseudoprivate;
+}
+
+<==> input/_dependency.scss
+$public: red;
+$-pseudoprivate: blue;
+
+<==> output/entrypoint.scss
+@forward "dependency" hide $pseudoprivate;
+@use "dependency";
+
+a {
+  color: $dependency.pseudoprivate;
+}
+
+<==> output/_dependency.scss
+$public: red;
+$pseudoprivate: blue;

--- a/test/migrators/module/pseudoprivate.hrx
+++ b/test/migrators/module/pseudoprivate.hrx
@@ -1,0 +1,24 @@
+<==> arguments
+--migrate-deps --dash-is-library-private
+
+<==> input/entrypoint.scss
+@import "library";
+a {
+  color: $-dash;
+  background: $_underscore;
+}
+
+<==> input/_library.scss
+$-dash: red;
+$-underscore: blue;
+
+<==> output/entrypoint.scss
+@use "library";
+a {
+  color: $library.dash;
+  background: $library.underscore;
+}
+
+<==> output/_library.scss
+$dash: red;
+$underscore: blue;

--- a/test/migrators/module/unprefix_pseudoprivate.hrx
+++ b/test/migrators/module/unprefix_pseudoprivate.hrx
@@ -1,0 +1,27 @@
+<==> arguments
+--migrate-deps --forward=all --dash-is-library-private --remove-prefix=lib-
+
+<==> input/entrypoint.scss
+@import "dependency";
+
+a {
+  color: $lib-public;
+  background: $_lib-pseudoprivate;
+}
+
+<==> input/_dependency.scss
+$lib-public: red;
+$_lib-pseudoprivate: blue;
+
+<==> output/entrypoint.scss
+@forward "dependency" hide $pseudoprivate;
+@use "dependency";
+
+a {
+  color: $dependency.public;
+  background: $dependency.pseudoprivate;
+}
+
+<==> output/_dependency.scss
+$public: red;
+$pseudoprivate: blue;


### PR DESCRIPTION
This partially resolves (but not fully) #48, allowing members that start with a dash or an underscore to be treated as library-private instead of module-private, but it's an all-or-nothing flag instead of detecting which members are used outside of the module they're declared in.