### PR TITLE
Support loading files from load-paths and node_modules

### DIFF
--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -60,6 +60,8 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
   ///
   /// If this is `null`, relative imports aren't supported in the current
   /// stylesheet.
+  @protected
+  Importer get importer => _importer;
   Importer _importer;
 
   MigrationVisitor(this.importCache, {this.migrateDependencies = true});

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -62,10 +62,9 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   /// Entrypoints and dependencies that did not require any changes will not be
   /// included in the results.
   Map<Uri, String> run() {
-    var allMigrated = Map<Uri, String>();
+    var allMigrated = <Uri, String>{};
     var importer = FilesystemImporter('.');
-    // TODO(jathak): Add support for passing loadPaths from command line.
-    var importCache = ImportCache([]);
+    var importCache = ImportCache([], loadPaths: globalResults['load-path']);
     for (var entrypoint in argResults.rest) {
       var tuple = importCache.import(Uri.parse(entrypoint), importer);
       if (tuple == null) {

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -15,6 +15,7 @@ import 'package:sass/src/import_cache.dart';
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
+import 'package:sass_migrator/src/util/node_modules_importer.dart';
 import 'package:source_span/source_span.dart';
 
 import 'utils.dart';
@@ -64,7 +65,8 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   Map<Uri, String> run() {
     var allMigrated = <Uri, String>{};
     var importer = FilesystemImporter('.');
-    var importCache = ImportCache([], loadPaths: globalResults['load-path']);
+    var importCache = ImportCache([NodeModulesImporter()],
+        loadPaths: globalResults['load-path']);
     for (var entrypoint in argResults.rest) {
       var tuple = importCache.import(Uri.parse(entrypoint), importer);
       if (tuple == null) {

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -67,7 +67,8 @@ class ModuleMigrator extends Migrator {
           'which prefixed members to forward.');
     }
     var references = References(importCache, stylesheet, importer);
-    var migrated = _ModuleMigrationVisitor(importCache, references,
+    var migrated = _ModuleMigrationVisitor(
+            importCache, references, globalResults['load-path'] as List<String>,
             prefixToRemove:
                 (argResults['remove-prefix'] as String)?.replaceAll('_', '-'),
             forward: forward)
@@ -128,6 +129,9 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   /// Cache used to load stylesheets.
   final ImportCache importCache;
 
+  /// List of paths that stylesheets can be loaded from.
+  final List<String> loadPaths;
+
   /// The prefix to be removed from any members with it, or null if no prefix
   /// should be removed.
   final String prefixToRemove;
@@ -139,10 +143,12 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   ///
   /// [importCache] must be the same one used by [references].
   ///
+  /// [loadPaths] should be the same list used to create [importCache].
+  ///
   /// Note: We always set [migratedDependencies] to true since the module
   /// migrator needs to always run on dependencies. The `migrateFile` method of
   /// the module migrator will filter out the dependencies' migration results.
-  _ModuleMigrationVisitor(this.importCache, this.references,
+  _ModuleMigrationVisitor(this.importCache, this.references, this.loadPaths,
       {this.prefixToRemove, this.forward})
       : super(importCache, migrateDependencies: true);
 
@@ -687,6 +693,13 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   String _absoluteUrlToDependency(Uri uri) {
     var relativePath =
         p.url.relative(uri.path, from: p.url.dirname(currentUrl.path));
+    for (var loadPath in loadPaths) {
+      var relativeToLoadPath =
+          p.url.relative(uri.path, from: p.absolute(loadPath));
+      if (relativeToLoadPath.length < relativePath.length) {
+        relativePath = relativeToLoadPath;
+      }
+    }
     var basename = p.url.basenameWithoutExtension(relativePath);
     if (basename.startsWith('_')) basename = basename.substring(1);
     return p.url.relative(p.url.join(p.url.dirname(relativePath), basename));

--- a/lib/src/runner.dart
+++ b/lib/src/runner.dart
@@ -22,6 +22,12 @@ class MigratorRunner extends CommandRunner<Map<Uri, String>> {
   MigratorRunner()
       : super("sass_migrator", "Migrates stylesheets to new Sass versions.") {
     argParser
+      ..addMultiOption('load-path',
+          abbr: 'I',
+          valueHelp: 'PATH',
+          help: 'A path to use when resolving imports.\n'
+              'May be passed multiple times.',
+          splitCommas: false)
       ..addFlag('migrate-deps',
           abbr: 'd',
           help: 'Migrate dependencies in addition to entrypoints.',

--- a/lib/src/util/node_modules_importer.dart
+++ b/lib/src/util/node_modules_importer.dart
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:path/path.dart' as p;
+import 'package:sass/sass.dart';
+
+import '../io.dart';
+
+/// An importer that resolves URLs starting with `~` by searching in
+/// `node_modules` directories.
+///
+/// This doesn't completely match Webpack's behavior (as it lacks the support
+/// for configuring its behavior), but it should be good enough to run the
+/// migrator with for most cases.
+class NodeModulesImporter extends Importer {
+  final _nodeModulesDirectories = <String>[];
+
+  /// Constructs a new [NodeModulesImporter] that searches for `node_modules` in
+  /// [baseDirectory] and all of its ancestors.
+  ///
+  /// If not provided, [baseDirectory] defaults to the current directory.
+  NodeModulesImporter([Directory baseDirectory]) {
+    var directory = baseDirectory ?? Directory.current;
+    while (true) {
+      var loadPath = p.join(directory.path, 'node_modules');
+      if (Directory(loadPath).existsSync()) {
+        _nodeModulesDirectories.add(loadPath);
+      }
+      var parent = p.dirname(directory.path);
+      if (directory.path == parent) break;
+      directory = Directory(parent);
+    }
+  }
+
+  /// Canonicalizes [url] using this importer.
+  ///
+  /// If [url] starts with `~`, this searches all `node_modules` directories,
+  /// using a [FilesystemImporter] to canonicalize to the real path on disk.
+  ///
+  /// If no matching stylesheet can be found, or if [url] does not start with
+  /// `~`, this returns null.
+  Uri canonicalize(Uri url) {
+    var path = url.toFilePath();
+    if (!path.startsWith('~') || path.startsWith('~/')) return null;
+    url = url.replace(path: path.substring(1));
+    for (var loadPath in _nodeModulesDirectories) {
+      var result = FilesystemImporter(loadPath).canonicalize(url);
+      if (result != null) return result;
+    }
+    return null;
+  }
+
+  /// Loads [url] using a [FilesystemImporter].
+  ///
+  /// [url] must be the canonical URL returned by [canonicalize].
+  ImporterResult load(Uri url) => FilesystemImporter('.').load(url);
+}

--- a/lib/src/util/node_modules_importer.dart
+++ b/lib/src/util/node_modules_importer.dart
@@ -16,22 +16,23 @@ import '../io.dart';
 /// for configuring its behavior), but it should be good enough to run the
 /// migrator with for most cases.
 class NodeModulesImporter extends Importer {
-  final _nodeModulesDirectories = <String>[];
+  /// Importers that load from various `node_modules` directories.
+  final _fsImporters = <FilesystemImporter>[];
 
   /// Constructs a new [NodeModulesImporter] that searches for `node_modules` in
   /// [baseDirectory] and all of its ancestors.
   ///
   /// If not provided, [baseDirectory] defaults to the current directory.
-  NodeModulesImporter([Directory baseDirectory]) {
-    var directory = baseDirectory ?? Directory.current;
+  NodeModulesImporter([String baseDirectory]) {
+    var directory = baseDirectory ?? p.current;
     while (true) {
-      var loadPath = p.join(directory.path, 'node_modules');
+      var loadPath = p.join(directory, 'node_modules');
       if (Directory(loadPath).existsSync()) {
-        _nodeModulesDirectories.add(loadPath);
+        _fsImporters.add(FilesystemImporter(loadPath));
       }
-      var parent = p.dirname(directory.path);
-      if (directory.path == parent) break;
-      directory = Directory(parent);
+      var parent = p.dirname(directory);
+      if (directory == parent) break;
+      directory = parent;
     }
   }
 
@@ -44,10 +45,11 @@ class NodeModulesImporter extends Importer {
   /// `~`, this returns null.
   Uri canonicalize(Uri url) {
     var path = url.toFilePath();
-    if (!path.startsWith('~') || path.startsWith('~/')) return null;
+    if (!path.startsWith('~')) return null;
+    if (path.startsWith('~/')) return null;
     url = url.replace(path: path.substring(1));
-    for (var loadPath in _nodeModulesDirectories) {
-      var result = FilesystemImporter(loadPath).canonicalize(url);
+    for (var importer in _fsImporters) {
+      var result = importer.canonicalize(url);
       if (result != null) return result;
     }
     return null;
@@ -56,5 +58,5 @@ class NodeModulesImporter extends Importer {
   /// Loads [url] using a [FilesystemImporter].
   ///
   /// [url] must be the canonical URL returned by [canonicalize].
-  ImporterResult load(Uri url) => FilesystemImporter('.').load(url);
+  ImporterResult load(Uri url) => _fsImporters.first.load(url);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   meta: ">=0.9.0 <2.0.0"
   path: "^1.6.0"
   term_glyph: "^1.1.0"
+  tuple: "^1.0.2"
 
 dev_dependencies:
   archive: ">=1.0.0 <3.0.0"

--- a/test/migrators/module/load_path.hrx
+++ b/test/migrators/module/load_path.hrx
@@ -1,0 +1,19 @@
+<==> arguments
+--migrate-deps --load-path a/b/c
+
+<==> input/entrypoint.scss
+@import "dependency";
+
+a {
+  color: $variable;
+}
+
+<==> input/a/b/c/_dependency.scss
+$variable: green;
+
+<==> output/entrypoint.scss
+@use "dependency";
+
+a {
+  color: dependency.$variable;
+}

--- a/test/migrators/module/load_path_indirect.hrx
+++ b/test/migrators/module/load_path_indirect.hrx
@@ -1,0 +1,28 @@
+<==> arguments
+--migrate-deps --load-path .
+
+<==> README
+This test confirms that the URLs of extra `@use` rules can be written relative
+to a load path instead of the current file if the resulting URL is shorter.
+
+<==> input/entrypoint/a/b/c.scss
+@import "direct";
+a {
+  color: $variable;
+}
+
+<==> input/_direct.scss
+@import "indirect";
+
+<==> input/_indirect.scss
+$variable: blue;
+
+<==> output/entrypoint/a/b/c.scss
+@use "indirect";
+@use "direct";
+a {
+  color: indirect.$variable;
+}
+
+<==> output/_direct.scss
+@use "indirect";

--- a/test/migrators/module/node_modules.hrx
+++ b/test/migrators/module/node_modules.hrx
@@ -1,0 +1,19 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "~module/dependency";
+
+a {
+  color: $variable;
+}
+
+<==> input/node_modules/module/_dependency.scss
+$variable: green;
+
+<==> output/entrypoint.scss
+@use "~module/dependency";
+
+a {
+  color: dependency.$variable;
+}

--- a/test/migrators/module/node_modules_indirect.hrx
+++ b/test/migrators/module/node_modules_indirect.hrx
@@ -1,0 +1,26 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "direct";
+
+a {
+  color: $variable;
+}
+
+<==> input/_direct.scss
+@import "~module/indirect";
+
+<==> input/node_modules/module/_indirect.scss
+$variable: green;
+
+<==> output/entrypoint.scss
+@use "~module/indirect";
+@use "direct";
+
+a {
+  color: indirect.$variable;
+}
+
+<==> output/_direct.scss
+@use "~module/indirect";


### PR DESCRIPTION
Fixes #58.
Fixes #68.

This adds the `--load-path` option to the executable and also implements an approximation of the Webpack `~` syntax that resolves these URLs to stylesheets within `node_modules` directories that should be good enough to run the migrator with for most cases.

**Wait to merge until after #76**