### PR TITLE
Error if renaming member in unmigrated file

### DIFF
--- a/test/migrators/module/unmigrated_rename.hrx
+++ b/test/migrators/module/unmigrated_rename.hrx
@@ -1,0 +1,16 @@
+<==> arguments
+--remove-prefix=lib-
+
+<==> input/entrypoint.scss
+@import "library";
+
+a {
+  color: $lib-variable;
+}
+
+<==> input/_library.scss
+$lib-variable: green;
+
+<==> error.txt
+Error: The migrator wants to rename a member in _library.scss, but it is not being migrated. You should re-run the migrator with --migrate-deps or with _library.scss as one of your entrypoints.
+Migration failed!


### PR DESCRIPTION
Fixes #84.
Fixes #85.

When running the module migrator without `--migrate-deps`, it's
possible that it may generate invalid member references if it renames
a member from a dependency that is not being migrated.

This adds an error when this happens that tells the user to re-run the
migrator with `--migrate-deps` or add the dependency as an entrypoint.