### PR TITLE
Make all members unreferencable in nested import

### DIFF
--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -699,8 +699,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       _unreferencable = UnreferencableMembers(_unreferencable);
       for (var declaration in references.allDeclarations) {
         if (declaration.sourceUrl != currentUrl) continue;
-        if (references.globalDeclarations.contains(declaration)) continue;
-        _unreferencable.add(declaration, UnreferencableType.localFromImporter);
+        _unreferencable.add(declaration, UnreferencableType.fromImporter);
       }
     }
     visitDependency(Uri.parse(import.url), import.span);
@@ -711,8 +710,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       _unreferencable = _unreferencable.parent;
       for (var declaration in references.allDeclarations) {
         if (declaration.sourceUrl != _lastUrl) continue;
-        _unreferencable.add(
-            declaration, UnreferencableType.globalFromNestedImport);
+        _unreferencable.add(declaration, UnreferencableType.fromNestedImport);
       }
     } else {
       var defaultNamespace = namespaceForPath(import.url);

--- a/lib/src/migrators/module/unreferencable_type.dart
+++ b/lib/src/migrators/module/unreferencable_type.dart
@@ -17,12 +17,11 @@ import '../../exception.dart';
 /// An enum of reasons why a member is unreferencable.
 @sealed
 class UnreferencableType {
-  /// For local members of the importing stylesheet within a nested import.
-  static const localFromImporter = UnreferencableType._('localFromImporter');
+  /// For members of the importing stylesheet within a nested import.
+  static const fromImporter = UnreferencableType._('fromImporter');
 
-  /// For global members from a nested import.
-  static const globalFromNestedImport =
-      UnreferencableType._('globalFromNestedImport');
+  /// For members from a nested import.
+  static const fromNestedImport = UnreferencableType._('fromNestedImport');
 
   /// Identifier for this unreferencable type.
   final String id;
@@ -37,14 +36,14 @@ class UnreferencableType {
         : reference is FunctionExpression ? 'function' : 'variable';
     var url = p.prettyUri(source);
     switch (this) {
-      case localFromImporter:
+      case fromImporter:
         return MigrationSourceSpanException(
-            "This stylesheet was loaded by a nested import in $url. The "
-            "module system only supports loading nested CSS using the "
-            "load-css() mixin, which doesn't allow access to local ${type}s "
-            "from the outer stylesheet.",
+            "This stylesheet was loaded by a nested import in $url. The module "
+            "system only supports loading nested CSS using the load-css() "
+            "mixin, which doesn't allow access to ${type}s from the outer "
+            "stylesheet.",
             reference.span);
-      case globalFromNestedImport:
+      case fromNestedImport:
         return MigrationSourceSpanException(
             "This $type was loaded from a nested import of $url. The module "
             "system only supports loading nested CSS using the load-css() "

--- a/test/migrators/module/load_css_global_reference.hrx
+++ b/test/migrators/module/load_css_global_reference.hrx
@@ -1,0 +1,23 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@mixin foo {
+  color: green;
+}
+
+@import "other";
+
+<==> input/_other.scss
+a {
+  @include foo;
+}
+
+<==> error.txt
+Error: This stylesheet was loaded by a nested import in entrypoint.scss. The module system only supports loading nested CSS using the load-css() mixin, which doesn't allow access to mixins from the outer stylesheet.
+  ,
+2 |   @include foo;
+  |   ^^^^^^^^^^^^
+  '
+  _other.scss 2:3  root stylesheet
+Migration failed!

--- a/test/migrators/module/load_css_local_reference.hrx
+++ b/test/migrators/module/load_css_local_reference.hrx
@@ -13,7 +13,7 @@ b {
 }
 
 <==> error.txt
-Error: This stylesheet was loaded by a nested import in entrypoint.scss. The module system only supports loading nested CSS using the load-css() mixin, which doesn't allow access to local variables from the outer stylesheet.
+Error: This stylesheet was loaded by a nested import in entrypoint.scss. The module system only supports loading nested CSS using the load-css() mixin, which doesn't allow access to variables from the outer stylesheet.
   ,
 2 |   c: $local;
   |      ^^^^^^

--- a/test/migrators/module/load_css_local_reference_indirect.hrx
+++ b/test/migrators/module/load_css_local_reference_indirect.hrx
@@ -18,7 +18,7 @@ c {
 }
 
 <==> error.txt
-Error: This stylesheet was loaded by a nested import in entrypoint.scss. The module system only supports loading nested CSS using the load-css() mixin, which doesn't allow access to local variables from the outer stylesheet.
+Error: This stylesheet was loaded by a nested import in entrypoint.scss. The module system only supports loading nested CSS using the load-css() mixin, which doesn't allow access to variables from the outer stylesheet.
   ,
 2 |   d: $local;
   |      ^^^^^^


### PR DESCRIPTION
Fixes #83.

Previously, only local members from the importing stylesheet would be
marked as unreferencable within a nested import, but references to
global members would create a circular dependency, so they shouldn't be
allowed either.