### PR TITLE
Improve importing files through load paths and node_modules

### DIFF
--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -126,6 +126,9 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
       var stylesheet = result.item2;
       visitStylesheet(stylesheet);
       _importer = oldImporter;
+    } else {
+      _missingDependencies.putIfAbsent(
+          context.sourceUrl.resolveUri(dependency), () => context);
     }
   }
 

--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -116,6 +116,9 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
       // If [dependency] comes from a non-relative import, don't migrate it,
       // because it's likely to be outside the user's repository and may even be
       // authored by a different person.
+      //
+      // TODO(nweiz): Add a flag to override this behavior for load paths
+      // (#104).
       if (result.item1 != _importer) return;
 
       var oldImporter = _importer;
@@ -123,19 +126,7 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
       var stylesheet = result.item2;
       visitStylesheet(stylesheet);
       _importer = oldImporter;
-    } else {
-      handleMissingDependency(dependency, context);
     }
-  }
-
-  /// Adds the missing [dependency] within the stylesheet at [source] to the
-  /// missing dependency list to warn after migration completes.
-  ///
-  /// Migrators should override this if they want a different behavior.
-  @protected
-  void handleMissingDependency(Uri dependency, FileSpan context) {
-    _missingDependencies.putIfAbsent(
-        context.sourceUrl.resolveUri(dependency), () => context);
   }
 
   /// Returns the migrated contents of this file, or null if the file does not

--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -58,7 +58,7 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
   Uri get currentUrl => _currentUrl;
   Uri _currentUrl;
 
-  /// The importer that's currently being used to resolve relative imports.
+  /// The importer that's being used to resolve relative imports.
   ///
   /// If this is `null`, relative imports aren't supported in the current
   /// stylesheet.
@@ -113,6 +113,11 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
   void visitDependency(Uri dependency, FileSpan context) {
     var result = importCache.import(dependency, _importer, _currentUrl);
     if (result != null) {
+      // If [dependency] comes from a non-relative import, don't migrate it,
+      // because it's likely to be outside the user's repository and may even be
+      // authored by a different person.
+      if (result.item1 != _importer) return;
+
       var oldImporter = _importer;
       _importer = result.item1;
       var stylesheet = result.item2;

--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -113,9 +113,11 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
   void visitDependency(Uri dependency, FileSpan context) {
     var result = importCache.import(dependency, _importer, _currentUrl);
     if (result != null) {
+      var oldImporter = _importer;
       _importer = result.item1;
       var stylesheet = result.item2;
       visitStylesheet(stylesheet);
+      _importer = oldImporter;
     } else {
       handleMissingDependency(dependency, context);
     }

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -87,7 +87,8 @@ abstract class Migrator extends Command<Map<Uri, String>> {
         if (allMigrated.containsKey(file) &&
             migrated[file] != allMigrated[file]) {
           throw MigrationException(
-              "$file is migrated in more than one way by these entrypoints.");
+              "The migrator has found multiple possible migrations for $file, "
+              "depending on the context in which it's loaded.");
         }
         allMigrated[file] = migrated[file];
       }

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -15,12 +15,13 @@ import 'package:sass/src/import_cache.dart';
 import 'package:args/command_runner.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
-import 'package:sass_migrator/src/util/node_modules_importer.dart';
 import 'package:source_span/source_span.dart';
 
 import 'exception.dart';
 import 'io.dart';
 import 'utils.dart';
+import 'util/node_modules_importer.dart';
+import 'util/reversible_filesystem_importer.dart';
 
 /// A migrator is a command that migrates the entrypoints provided to it and
 /// (optionally) their dependencies.
@@ -74,8 +75,11 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   Map<Uri, String> run() {
     var allMigrated = <Uri, String>{};
     var importer = FilesystemImporter('.');
-    var importCache = ImportCache([NodeModulesImporter()],
-        loadPaths: globalResults['load-path']);
+    var importCache = ImportCache([
+      for (var path in globalResults['load-path'] as List<String>)
+        ReversibleFilesystemImporter(path),
+      NodeModulesImporter()
+    ]);
     for (var entrypoint in argResults.rest) {
       var tuple = importCache.import(Uri.parse(entrypoint), importer);
       if (tuple == null) {

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -15,15 +15,13 @@ import 'package:args/args.dart';
 import 'package:collection/collection.dart';
 import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
-import 'package:tuple/tuple.dart';
 
 import '../exception.dart';
 import '../migration_visitor.dart';
 import '../migrator.dart';
 import '../patch.dart';
 import '../utils.dart';
-import '../util/node_modules_importer.dart';
-
+import '../util/reversible_importer.dart';
 import 'module/built_in_functions.dart';
 import 'module/forward_type.dart';
 import 'module/member_declaration.dart';
@@ -121,10 +119,6 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   /// declaration will be used for namespacing instead of this one.
   final _reassignedVariables = <MemberDeclaration<VariableDeclaration>>{};
 
-  /// Maps canonical URLs to the original URL and importer from the `@import`
-  /// rule that last imported that URL.
-  final _originalImports = <Uri, Tuple2<String, Importer>>{};
-
   /// Tracks members that are unreferencable in the current scope.
   UnreferencableMembers _unreferencable = UnreferencableMembers();
 
@@ -150,6 +144,10 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
 
   /// Whether @use and @forward are allowed in the current context.
   var _useAllowed = true;
+
+  /// The importer used to load files relative to the entrypoint, as opposed to
+  /// through `node_modules` or load paths.
+  Importer _entrypointImporter;
 
   /// A mapping between member declarations and references.
   ///
@@ -192,6 +190,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   /// migrator.
   @override
   Map<Uri, String> run(Stylesheet stylesheet, Importer importer) {
+    _entrypointImporter = importer;
     references.globalDeclarations.forEach(_renameDeclaration);
     var migrated = super.run(stylesheet, importer);
 
@@ -689,13 +688,8 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (migrateDependencies) visitDependency(parsedUrl, import.span);
     _upstreamStylesheets.remove(currentUrl);
 
-    // Associate the importer for this URL with the resolved URL so that we can
-    // re-use this import URL later on.
-    var tuple = importCache.canonicalize(parsedUrl, importer, currentUrl);
-    var resolvedUrl = tuple.item2;
-    _originalImports.putIfAbsent(
-        resolvedUrl, () => Tuple2(import.url, tuple.item1));
-
+    var resolvedUrl =
+        importCache.canonicalize(parsedUrl, importer, currentUrl).item2;
     var asClause = '';
     if (!_useAllowed) {
       _unreferencable = _unreferencable.parent;
@@ -957,8 +951,11 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   /// `@use`, `@forward`, or `@import` rule.
   String _absoluteUrlToDependency(Uri url, {Uri relativeTo}) {
     relativeTo ??= currentUrl;
-    var tuple = _originalImports[url];
-    if (tuple?.item2 is NodeModulesImporter) return tuple.item1;
+
+    var importer = references.importers[url];
+    if (importer != _entrypointImporter) {
+      return (importer as ReversibleImporter).decanonicalize(url).toString();
+    }
 
     var loadPathUrls = loadPaths.map((path) => p.toUri(p.absolute(path)));
     var potentialUrls = [

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -320,14 +320,9 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
               import.span);
         }
 
-        // TODO(nweiz): Rather than skipping a stylesheet we've already visited,
-        // visit it again and throw an error if it produces different results
-        // (#99).
-        var url = result.item2.span.sourceUrl;
-        if (_importers.containsKey(url)) return;
-
         var oldImporter = _importer;
         _importer = result.item1;
+        var url = result.item2.span.sourceUrl;
         _importers[url] = _importer;
         visitStylesheet(result.item2);
         var importSource = ImportSource(url, import);

--- a/lib/src/util/node_modules_importer.dart
+++ b/lib/src/util/node_modules_importer.dart
@@ -44,10 +44,11 @@ class NodeModulesImporter extends Importer {
   /// If no matching stylesheet can be found, or if [url] does not start with
   /// `~`, this returns null.
   Uri canonicalize(Uri url) {
-    var path = url.toFilePath();
-    if (!path.startsWith('~')) return null;
-    if (path.startsWith('~/')) return null;
-    url = url.replace(path: path.substring(1));
+    if (url.scheme == 'file') return _fsImporters.first.canonicalize(url);
+
+    if (!url.path.startsWith('~')) return null;
+    if (url.path.startsWith('~/')) return null;
+    url = url.replace(path: url.path.substring(1));
     for (var importer in _fsImporters) {
       var result = importer.canonicalize(url);
       if (result != null) return result;

--- a/lib/src/util/node_modules_importer.dart
+++ b/lib/src/util/node_modules_importer.dart
@@ -8,6 +8,8 @@ import 'package:path/path.dart' as p;
 import 'package:sass/sass.dart';
 
 import '../io.dart';
+import '../utils.dart';
+import 'reversible_importer.dart';
 
 /// An importer that resolves URLs starting with `~` by searching in
 /// `node_modules` directories.
@@ -15,9 +17,13 @@ import '../io.dart';
 /// This doesn't completely match Webpack's behavior (as it lacks the support
 /// for configuring its behavior), but it should be good enough to run the
 /// migrator with for most cases.
-class NodeModulesImporter extends Importer {
+class NodeModulesImporter extends Importer implements ReversibleImporter {
   /// Importers that load from various `node_modules` directories.
   final _fsImporters = <FilesystemImporter>[];
+
+  /// The paths to the `node_modules` directories in which this importer
+  /// searches for stylesheets.
+  final _nodeModules = <String>[];
 
   /// Constructs a new [NodeModulesImporter] that searches for `node_modules` in
   /// [baseDirectory] and all of its ancestors.
@@ -28,6 +34,7 @@ class NodeModulesImporter extends Importer {
     while (true) {
       var loadPath = p.join(directory, 'node_modules');
       if (Directory(loadPath).existsSync()) {
+        _nodeModules.add(loadPath);
         _fsImporters.add(FilesystemImporter(loadPath));
       }
       var parent = p.dirname(directory);
@@ -54,6 +61,15 @@ class NodeModulesImporter extends Importer {
       if (result != null) return result;
     }
     return null;
+  }
+
+  Uri decanonicalize(Uri url) {
+    var path = p.fromUri(url);
+    for (var dir in _nodeModules) {
+      if (!p.isWithin(dir, path)) continue;
+      return cleanBasename(p.toUri('~' + p.relative(path, from: dir)));
+    }
+    throw ArgumentError("Couldn't find $url in any node_modules directory.");
   }
 
   /// Loads [url] using a [FilesystemImporter].

--- a/lib/src/util/reversible_filesystem_importer.dart
+++ b/lib/src/util/reversible_filesystem_importer.dart
@@ -1,0 +1,34 @@
+// Copyright 2019 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:path/path.dart' as p;
+import 'package:sass/sass.dart';
+
+import '../utils.dart';
+import 'reversible_importer.dart';
+
+/// A version of [FilesystemImporter] that implements [ReversibleImporter] as
+/// well.
+class ReversibleFilesystemImporter extends Importer
+    implements ReversibleImporter {
+  /// The wrapped importer to which this delegates.
+  final FilesystemImporter _inner;
+
+  /// The path relative to which this importer looks for files.
+  final String _loadPath;
+
+  ReversibleFilesystemImporter(this._loadPath)
+      : _inner = FilesystemImporter(_loadPath);
+
+  Uri decanonicalize(Uri canonicalUrl) => cleanBasename(
+      p.toUri(p.relative(p.fromUri(canonicalUrl), from: _loadPath)));
+
+  Uri canonicalize(Uri url) => _inner.canonicalize(url);
+
+  ImporterResult load(Uri canonicalUrl) => _inner.load(canonicalUrl);
+
+  String toString() => _inner.toString();
+}

--- a/lib/src/util/reversible_importer.dart
+++ b/lib/src/util/reversible_importer.dart
@@ -1,0 +1,18 @@
+// Copyright 2019 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'package:sass/sass.dart';
+
+/// An [Importer] interface that supports converting canonical URLs back into
+/// their non-canonical forms.
+abstract class ReversibleImporter implements Importer {
+  /// Converts [canonicalUrl] into a non-canonical form.
+  ///
+  /// Callers should only call this with [canonicalUrl]s returned by this
+  /// importer. Implementors must guarantee that calling
+  /// `canonicalize(decanonicalize(url))` will return the original `url`.
+  Uri decanonicalize(Uri canonicalUrl);
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -5,6 +5,7 @@
 // https://opensource.org/licenses/MIT.
 
 import 'package:charcode/charcode.dart';
+import 'package:path/path.dart' as p;
 import 'package:source_span/source_span.dart';
 import 'package:tuple/tuple.dart';
 
@@ -193,6 +194,14 @@ Uri getImportOnlyUrl(Uri url) {
   var extension = filename.split('.').last;
   var basename = filename.substring(0, filename.length - extension.length - 1);
   return url.resolve('$basename.import.$extension');
+}
+
+/// Removes a non-canonical URL's basename's initial `_` and extension.
+Uri cleanBasename(Uri url) {
+  var string = url.toString();
+  var basename = p.url.basenameWithoutExtension(string);
+  if (basename.startsWith("_")) basename = basename.substring(1);
+  return Uri.parse(p.url.join(p.url.dirname(string), basename));
 }
 
 /// Partitions [iterable] into two lists based on the types of its inputs.

--- a/test/migrators/module/doesnt_migrate_through_load_path.hrx
+++ b/test/migrators/module/doesnt_migrate_through_load_path.hrx
@@ -1,0 +1,23 @@
+<==> arguments
+--migrate-deps --load-path a/b/c
+
+<==> input/entrypoint.scss
+@import "dependency";
+
+a {
+  color: $variable;
+}
+
+<==> input/a/b/c/_dependency.scss
+@import "other"
+
+<==> input/a/b/c/_other.scss
+$variable: green;
+
+<==> output/entrypoint.scss
+@use "other";
+@use "dependency";
+
+a {
+  color: other.$variable;
+}

--- a/test/migrators/module/doesnt_migrate_through_node_modules.hrx
+++ b/test/migrators/module/doesnt_migrate_through_node_modules.hrx
@@ -1,0 +1,23 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "~module/dependency";
+
+a {
+  color: $variable;
+}
+
+<==> input/node_modules/module/_dependency.scss
+@import "other";
+
+<==> input/node_modules/module/_other.scss
+$variable: green;
+
+<==> output/entrypoint.scss
+@use "~module/other";
+@use "~module/dependency";
+
+a {
+  color: other.$variable;
+}

--- a/test/migrators/module/load_path_indirect.hrx
+++ b/test/migrators/module/load_path_indirect.hrx
@@ -1,28 +1,25 @@
 <==> arguments
---migrate-deps --load-path .
+--migrate-deps --load-path load_path
 
 <==> README
 This test confirms that the URLs of extra `@use` rules can be written relative
 to a load path instead of the current file if the resulting URL is shorter.
 
-<==> input/entrypoint/a/b/c.scss
+<==> input/entrypoint.scss
 @import "direct";
 a {
   color: $variable;
 }
 
-<==> input/_direct.scss
+<==> input/load_path/_direct.scss
 @import "indirect";
 
-<==> input/_indirect.scss
+<==> input/load_path/_indirect.scss
 $variable: blue;
 
-<==> output/entrypoint/a/b/c.scss
+<==> output/entrypoint.scss
 @use "indirect";
 @use "direct";
 a {
   color: indirect.$variable;
 }
-
-<==> output/_direct.scss
-@use "indirect";

--- a/test/migrators/module/overridden_function.hrx
+++ b/test/migrators/module/overridden_function.hrx
@@ -1,0 +1,22 @@
+<==> input/entrypoint.scss
+@import "a";
+@import "b";
+
+a {
+  color: fn();
+}
+
+<==> input/_a.scss
+@import "b";
+@function fn() {@return blue;}
+
+<==> input/_b.scss
+@function fn() {@return green;}
+
+<==> output/entrypoint.scss
+@use "a";
+@use "b";
+
+a {
+  color: b.fn();
+}


### PR DESCRIPTION
Most pertinently, we no longer migrate files in those locations, and
we properly generate @uses for dependencies within them.