### PR TITLE
Add parens around negated variable when namespaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   only be considered configured when the configuring declaration is upstream of
   the `!default` declaration.
 
+* When namespacing a negated variable, adds parentheses around it to prevent the
+  `-` from being parsed as part of the namespace.
+
+* Fix a bug in the migrating of removed color functions when the amount is a
+  variable being namespaced.
+
 ## 1.0.0
 
 * Initial release.

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -522,44 +522,46 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   /// Adds a namespace to any function call that requires it.
   @override
   void visitFunctionExpression(FunctionExpression node) {
-    if (node.namespace == null) {
-      if (references.sources.containsKey(node)) {
-        var declaration = references.functions[node];
-        _unreferencable.check(declaration, node);
-        _renameReference(nameSpan(node), declaration);
-        _patchNamespaceForFunction(node, declaration, (namespace) {
-          addPatch(patchBefore(node.name, '$namespace.'));
-        });
+    if (node.namespace != null) {
+      super.visitFunctionExpression(node);
+      return;
+    }
+    if (references.sources.containsKey(node)) {
+      var declaration = references.functions[node];
+      _unreferencable.check(declaration, node);
+      _renameReference(nameSpan(node), declaration);
+      _patchNamespaceForFunction(node, declaration, (namespace) {
+        addPatch(patchBefore(node.name, '$namespace.'));
+      });
+    }
+
+    if (node.name.asPlain == "get-function") {
+      var declaration = references.getFunctionReferences[node];
+      _unreferencable.check(declaration, node);
+      _renameReference(getStaticNameForGetFunctionCall(node), declaration);
+
+      // Ignore get-function calls that already have a module argument.
+      var moduleArg = node.arguments.named['module'];
+      if (moduleArg == null && node.arguments.positional.length > 2) {
+        moduleArg = node.arguments.positional[2];
+      }
+      if (moduleArg != null) return;
+
+      // Warn for get-function calls without a static name.
+      var nameArg =
+          node.arguments.named['name'] ?? node.arguments.positional.first;
+      if (nameArg is! StringExpression ||
+          (nameArg as StringExpression).text.asPlain == null) {
+        emitWarning(
+            "get-function call may require \$module parameter", nameArg.span);
+        return;
       }
 
-      if (node.name.asPlain == "get-function") {
-        var declaration = references.getFunctionReferences[node];
-        _unreferencable.check(declaration, node);
-        _renameReference(getStaticNameForGetFunctionCall(node), declaration);
-
-        // Ignore get-function calls that already have a module argument.
-        var moduleArg = node.arguments.named['module'];
-        if (moduleArg == null && node.arguments.positional.length > 2) {
-          moduleArg = node.arguments.positional[2];
-        }
-        if (moduleArg != null) return;
-
-        // Warn for get-function calls without a static name.
-        var nameArg =
-            node.arguments.named['name'] ?? node.arguments.positional.first;
-        if (nameArg is! StringExpression ||
-            (nameArg as StringExpression).text.asPlain == null) {
-          emitWarning(
-              "get-function call may require \$module parameter", nameArg.span);
-          return;
-        }
-
-        _patchNamespaceForFunction(node, declaration, (namespace) {
-          var beforeParen = node.span.end.offset - 1;
-          addPatch(Patch(node.span.file.span(beforeParen, beforeParen),
-              ', \$module: "$namespace"'));
-        }, getFunctionCall: true);
-      }
+      _patchNamespaceForFunction(node, declaration, (namespace) {
+        var beforeParen = node.span.end.offset - 1;
+        addPatch(Patch(node.span.file.span(beforeParen, beforeParen),
+            ', \$module: "$namespace"'));
+      }, getFunctionCall: true);
     }
     super.visitFunctionExpression(node);
   }
@@ -636,8 +638,11 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   void _patchRemovedColorFunction(String name, Expression arg,
       {FileSpan existingArgName}) {
     var parameter = removedColorFunctions[name];
+    // Surround the argument in parens if negated to avoid `-` being parsed
+    // as part of the namespace.
     var needsParens = parameter.endsWith('-') &&
         (arg is BinaryOperationExpression ||
+            arg is FunctionExpression ||
             (arg is VariableExpression &&
                 references.variables[arg]?.sourceUrl != currentUrl));
     var leftParen = needsParens ? '(' : '';
@@ -932,7 +937,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (namespace != null) {
       // Surround the variable in parens if negated to avoid `-` being parsed
       // as part of the namespace.
-      var negated = extendBackward(node.span, '-') != null;
+      var negated = matchesBeforeSpan(node.span, '-');
       if (negated) addPatch(patchBefore(node, '('));
       addPatch(patchBefore(node, '$namespace.'));
       if (negated) addPatch(patchAfter(node, ')'));

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -85,6 +85,13 @@ FileSpan extendBackward(FileSpan span, String text) {
   return span.file.span(start - text.length, span.end.offset);
 }
 
+/// Returns true if [span] is preceded by exactly [text].
+bool matchesBeforeSpan(FileSpan span, String text) {
+  var start = span.start.offset;
+  if (start - text.length < 0) return false;
+  return span.file.getText(start - text.length, start) == text;
+}
+
 /// Returns whether [character] is whitespace, according to Sass's definition.
 bool isWhitespace(int character) =>
     character == $space ||

--- a/test/migrators/module/namespace_negated_variables.hrx
+++ b/test/migrators/module/namespace_negated_variables.hrx
@@ -1,0 +1,21 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "library";
+a {
+  b: -$amount;
+  color: darken($color, $amount);
+}
+
+<==> input/_library.scss
+$color: blue;
+$amount: 10%;
+
+<==> output/entrypoint.scss
+@use "sass:color";
+@use "library";
+a {
+  b: -(library.$amount);
+  color: color.adjust(library.$color, $lightness: -(library.$amount));
+}

--- a/test/migrators/module/namespace_negation.hrx
+++ b/test/migrators/module/namespace_negation.hrx
@@ -6,6 +6,7 @@
 a {
   b: -$amount;
   color: darken($color, $amount);
+  background: darken($color, fn());
 }
 
 <==> input/_library.scss
@@ -18,4 +19,5 @@ $amount: 10%;
 a {
   b: -(library.$amount);
   color: color.adjust(library.$color, $lightness: -(library.$amount));
+  background: color.adjust(library.$color, $lightness: -(fn()));
 }


### PR DESCRIPTION
Fixes #114.

In fixing this, I also found a fixed a bug when migrating removed color
functions, as a patch to namespace the argument would be applied before
the patch adding the new argument name. This was fixed by ensuring the
arguments of a function expression are visited after the function itself
is patched.