### PR TITLE
Add flag to always generate import-only files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 * Add support for glob inputs on the command line.
 
+### Module Migrator
+
+* Add new `--import-only-for-all` flag that generates import-only stylesheets
+  for all files with removed prefixes, instead of just entrypoints.
+
 ## 1.0.1
 
 ### Module Migrator

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,12 +93,12 @@ packages:
     source: hosted
     version: "0.1.26"
   glob:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.7"
+    version: "1.2.0"
   grinder:
     dependency: "direct dev"
     description:

--- a/test/migrators/module/remove_prefix_flag/import_only_all.hrx
+++ b/test/migrators/module/remove_prefix_flag/import_only_all.hrx
@@ -1,0 +1,26 @@
+<==> arguments
+--migrate-deps --remove-prefix=lib- --forward=all --import-only-all
+
+<==> input/entrypoint.scss
+@import "prefix";
+@import "no-prefix";
+
+<==> input/_prefix.scss
+$lib-variable: green;
+
+<==> input/_no-prefix.scss
+$unprefixed: blue;
+
+<==> output/entrypoint.scss
+@forward "prefix";
+@forward "no-prefix";
+
+<==> output/entrypoint.import.scss
+@forward "entrypoint" as lib-* hide $lib-unprefixed;
+@forward "entrypoint" show $unprefixed;
+
+<==> output/_prefix.scss
+$variable: green;
+
+<==> output/_prefix.import.scss
+@forward "prefix" as lib-*;


### PR DESCRIPTION
Fixes #121.

I'm not super happy with `--import-only-for-all` as a flag name, so let me know if you think there's something simpler or clearer to use.