### PR TITLE
Delete only the prefix when renaming

### DIFF
--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -1016,7 +1016,13 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   void _renameReference(FileSpan span, MemberDeclaration declaration) {
     if (declaration == null) return;
     if (renamedMembers.containsKey(declaration)) {
-      addPatch(Patch(span, renamedMembers[declaration]));
+      var newName = renamedMembers[declaration];
+      if (declaration.name.endsWith(newName)) {
+        addPatch(
+            patchDelete(span, end: declaration.name.length - newName.length));
+      } else {
+        addPatch(Patch(span, newName));
+      }
       return;
     }
 

--- a/test/migrators/module/remove_prefix_flag/preserve_underscores.hrx
+++ b/test/migrators/module/remove_prefix_flag/preserve_underscores.hrx
@@ -1,0 +1,10 @@
+<==> arguments
+--remove-prefix=lib-
+<==> input/entrypoint.scss
+$lib_variable_with_underscores: green;
+
+<==> output/entrypoint.scss
+$variable_with_underscores: green;
+
+<==> output/entrypoint.import.scss
+@forward "entrypoint" as lib-*;


### PR DESCRIPTION
Previously, renaming references involved patching the entire name, which
had the side of effect of converting all underscores in the original
name to dashes. This now preserves those underscores by only patching
the removed prefix.