### PR TITLE
Support more complex forwards in import-only files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Add support for glob inputs on the command line.
 
+* Better handling when migrating files whose dependencies have complex
+  import-only files.
+
 ### Module Migrator
 
 * Make `--remove-prefix=<prefix> --forward=prefixed` forward members that

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -75,8 +75,6 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   Map<Uri, String> run() {
     var allMigrated = <Uri, String>{};
     var importer = FilesystemImporter('.');
-    var importCache = ImportCache([NodeModulesImporter()],
-        loadPaths: globalResults['load-path']);
 
     var entrypoints = [
       for (var argument in argResults.rest)
@@ -84,6 +82,8 @@ abstract class Migrator extends Command<Map<Uri, String>> {
           if (entry is File) entry.path
     ];
     for (var entrypoint in entrypoints) {
+      var importCache = ImportCache([NodeModulesImporter()],
+          loadPaths: globalResults['load-path']);
       var tuple = importCache.import(Uri.parse(entrypoint), importer);
       if (tuple == null) {
         throw MigrationException("Could not find Sass file at '$entrypoint'.");

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -459,7 +459,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       };
       // Start each rule's namespace at the default.
       var aliases = {for (var source in sources) source: namespace};
-
+      
       // While multiple rules have the same namespace or any rule's
       // namespace is already present, add the next path segment to all
       // namespaces at once.
@@ -746,11 +746,13 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (migrateDependencies) visitDependency(parsedUrl, import.span);
     _upstreamStylesheets.remove(currentUrl);
 
-    // Associate the importer for this URL with the resolved URL so that we can
-    // re-use this import URL later on.
-
+    // Clear the cache for this URL and re-canonicalize it for a `@use` rule.
+    importCache.clearCanonicalize(parsedUrl);
     var tuple = inUseRule(
         () => importCache.canonicalize(parsedUrl, importer, currentUrl));
+
+    // Associate the importer for this URL with the resolved URL so that we can
+    // re-use this import URL later on.
     var resolvedUrl = tuple.item2;
     _originalImports.putIfAbsent(
         resolvedUrl, () => Tuple2(import.url, tuple.item1));

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -407,11 +407,9 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     for (var reference in references.sources.keys) {
       if (reference.span.sourceUrl != url) continue;
       var source = references.sources[reference];
-      if (source is ImportSource) {
-        if (source.ruleUrl == null) {
-          source.ruleUrl =
-              _absoluteUrlToDependency(source.url, relativeTo: url).item1;
-        }
+      if (source is ImportSource && source.ruleUrl == null) {
+        source.ruleUrl =
+            _absoluteUrlToDependency(source.url, relativeTo: url).item1;
       }
       var namespace = source.defaultNamespace;
       if (namespace == null) continue;

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -9,6 +9,7 @@
 // https://github.com/sass/dart-sass/issues/236.
 import 'package:sass/src/ast/sass.dart';
 import 'package:sass/src/importer.dart';
+import 'package:sass/src/importer/utils.dart';
 import 'package:sass/src/import_cache.dart';
 
 import 'package:args/args.dart';
@@ -451,7 +452,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       // namespace.
       var paths = {
         for (var source in sources)
-          source: Uri.parse(source.import.url).pathSegments.toList()
+          source: Uri.parse(source.ruleUrl).pathSegments.toList()
             ..removeLast()
             ..removeWhere((segment) => segment.contains('.'))
       };
@@ -512,7 +513,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   List<Set<ImportSource>> _orderSources(Iterable<ImportSource> sources) {
     var byPathLength = <int, Set<ImportSource>>{};
     for (var source in sources) {
-      var pathSegments = Uri.parse(source.import.url).pathSegments;
+      var pathSegments = Uri.parse(source.ruleUrl).pathSegments;
       byPathLength.putIfAbsent(pathSegments.length, () => {}).add(source);
     }
     return [
@@ -746,7 +747,9 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
 
     // Associate the importer for this URL with the resolved URL so that we can
     // re-use this import URL later on.
-    var tuple = importCache.canonicalize(parsedUrl, importer, currentUrl);
+
+    var tuple = inUseRule(
+        () => importCache.canonicalize(parsedUrl, importer, currentUrl));
     var resolvedUrl = tuple.item2;
     _originalImports.putIfAbsent(
         resolvedUrl, () => Tuple2(import.url, tuple.item1));

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -407,6 +407,12 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     for (var reference in references.sources.keys) {
       if (reference.span.sourceUrl != url) continue;
       var source = references.sources[reference];
+      if (source is ImportSource) {
+        if (source.ruleUrl == null) {
+          source.ruleUrl =
+              _absoluteUrlToDependency(source.url, relativeTo: url).item1;
+        }
+      }
       var namespace = source.defaultNamespace;
       if (namespace == null) continue;
 
@@ -451,15 +457,13 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       // namespace.
       var paths = {
         for (var source in sources)
-          source: _absoluteUrlToDependency(source.url, relativeTo: currentUrl)
-              .item1
-              .split('/')
-                ..removeLast()
-                ..removeWhere((segment) => segment.contains('.'))
+          source: source.ruleUrl.split('/')
+            ..removeLast()
+            ..removeWhere((segment) => segment.contains('.'))
       };
       // Start each rule's namespace at the default.
       var aliases = {for (var source in sources) source: namespace};
-      
+
       // While multiple rules have the same namespace or any rule's
       // namespace is already present, add the next path segment to all
       // namespaces at once.

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -436,6 +436,9 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
 
   /// Resolves a conflict between a set of sources with the same default
   /// namespace, adding namespaces for all of them to [namespaces].
+  ///
+  /// [currentUrl] is the canonical URL of the file that contains all of the
+  /// references in [sources].
   void _resolveNamespaceConflict(String namespace, Set<ReferenceSource> sources,
       Map<Uri, String> namespaces, Uri currentUrl) {
     // Give first priority to a built-in module.
@@ -750,7 +753,9 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (migrateDependencies) visitDependency(parsedUrl, import.span);
     _upstreamStylesheets.remove(currentUrl);
 
-    // Clear the cache for this URL and re-canonicalize it for a `@use` rule.
+    // Clear the cache for this URL and re-canonicalize it for a `@use` rule,
+    // since it was previously canonicalized for an `@import` rule.
+    // TODO(jathak): Remove this once dart-sass#899 is fixed
     importCache.clearCanonicalize(parsedUrl);
     var tuple = inUseRule(
         () => importCache.canonicalize(parsedUrl, importer, currentUrl));

--- a/lib/src/migrators/module/member_declaration.dart
+++ b/lib/src/migrators/module/member_declaration.dart
@@ -9,8 +9,6 @@
 // https://github.com/sass/dart-sass/issues/236.
 import 'package:sass/src/ast/sass.dart';
 
-import '../../utils.dart';
-
 /// A wrapper class for nodes that declare a variable, function, or mixin.
 ///
 /// The member this class wraps will always be a [VariableDeclaration],
@@ -32,13 +30,19 @@ class MemberDeclaration<T extends SassNode> {
   /// The URL this member came from.
   ///
   /// For un-forwarded members, this is the URL the member was declared in.
-  /// For forwarded members, this is the URL of the `@forward` rule.
+  /// For members forwarded through an import-only file, this is the [sourceUrl]
+  /// of the member prior to that forward.
+  /// For other forwarded members, this is the URL of the `@forward` rule.
   final Uri sourceUrl;
 
   /// The canonical URL forwarded by [forward].
   ///
   /// This is `null` when [forward] is.
   final Uri forwardedUrl;
+
+  /// True if this declaration is the result of a `@forward` rule within an
+  /// import-only stylesheet.
+  final bool isImportOnly;
 
   /// Constructs a MemberDefinition for [member], which must be a
   /// [VariableDeclaration], [Argument], [MixinRule], or [FunctionRule].
@@ -54,7 +58,8 @@ class MemberDeclaration<T extends SassNode> {
         })(),
         sourceUrl = member.span.sourceUrl,
         forward = null,
-        forwardedUrl = null;
+        forwardedUrl = null,
+        isImportOnly = false;
 
   /// Constructs a forwarded MemberDefinition of [forwarding] based on
   /// [forward].
@@ -62,13 +67,10 @@ class MemberDeclaration<T extends SassNode> {
       MemberDeclaration forwarding, this.forward, this.forwardedUrl)
       : member = forwarding.member,
         name = '${forward.prefix ?? ""}${forwarding.name}',
-        sourceUrl = forward.span.sourceUrl;
-
-  /// Returns true if this declaration is the result of a `@forward` rule within
-  /// an import-only stylesheet.
-  bool get isImportOnly =>
-      forward != null &&
-      forward.span.sourceUrl == getImportOnlyUrl(forwardedUrl);
+        isImportOnly = _isImportOnly(forward),
+        sourceUrl = _isImportOnly(forward)
+            ? forwarding.sourceUrl
+            : forward.span.sourceUrl;
 
   operator ==(other) =>
       other is MemberDeclaration &&
@@ -77,3 +79,9 @@ class MemberDeclaration<T extends SassNode> {
 
   int get hashCode => member.hashCode;
 }
+
+/// Returns true if [forward] is non-null and inside an import-only file.
+bool _isImportOnly(ForwardRule forward) =>
+    forward != null &&
+    (forward.span.sourceUrl.path.endsWith('.import.scss') ||
+        forward.span.sourceUrl.path.endsWith('.import.sass'));

--- a/lib/src/migrators/module/member_declaration.dart
+++ b/lib/src/migrators/module/member_declaration.dart
@@ -31,10 +31,10 @@ class MemberDeclaration<T extends SassNode> {
 
   /// The URL this member came from.
   ///
-  /// For un-forwarded members, this is the URL the member was declared in.
-  /// For members forwarded through an import-only file, this is the [sourceUrl]
-  /// of the member prior to that forward.
-  /// For other forwarded members, this is the URL of the `@forward` rule.
+  /// For un-forwarded members, this is the URL the member was declared in. For
+  /// members forwarded through an import-only file, this is the [sourceUrl] of
+  /// the member prior to that forward. For other forwarded members, this is the
+  /// URL of the `@forward` rule.
   final Uri sourceUrl;
 
   /// The canonical URL forwarded by [forward].

--- a/lib/src/migrators/module/member_declaration.dart
+++ b/lib/src/migrators/module/member_declaration.dart
@@ -9,6 +9,8 @@
 // https://github.com/sass/dart-sass/issues/236.
 import 'package:sass/src/ast/sass.dart';
 
+import '../../utils.dart';
+
 /// A wrapper class for nodes that declare a variable, function, or mixin.
 ///
 /// The member this class wraps will always be a [VariableDeclaration],
@@ -67,8 +69,8 @@ class MemberDeclaration<T extends SassNode> {
       MemberDeclaration forwarding, this.forward, this.forwardedUrl)
       : member = forwarding.member,
         name = '${forward.prefix ?? ""}${forwarding.name}',
-        isImportOnly = _isImportOnly(forward),
-        sourceUrl = _isImportOnly(forward)
+        isImportOnly = isImportOnlyFile(forward.span.sourceUrl),
+        sourceUrl = isImportOnlyFile(forward.span.sourceUrl)
             ? forwarding.sourceUrl
             : forward.span.sourceUrl;
 
@@ -79,9 +81,3 @@ class MemberDeclaration<T extends SassNode> {
 
   int get hashCode => member.hashCode;
 }
-
-/// Returns true if [forward] is non-null and inside an import-only file.
-bool _isImportOnly(ForwardRule forward) =>
-    forward != null &&
-    (forward.span.sourceUrl.path.endsWith('.import.scss') ||
-        forward.span.sourceUrl.path.endsWith('.import.sass'));

--- a/lib/src/migrators/module/reference_source.dart
+++ b/lib/src/migrators/module/reference_source.dart
@@ -27,7 +27,7 @@ abstract class ReferenceSource {
 class ImportSource extends ReferenceSource {
   final Uri url;
 
-  /// The URL within the `@import` rule that loaded this member, or null if this
+  /// The URL of the `@import` rule that loaded this member, or null if this
   /// is for an indirect dependency forwarded in an import-only file.
   final String originalRuleUrl;
 

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -340,7 +340,11 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
         _importer = result.item1;
         var oldLibraryUrl = _libraryUrl;
         var url = result.item2.span.sourceUrl;
-        if (_importer != oldImporter) _libraryUrl ??= url;
+        if (_importer != oldImporter &&
+            !url.toString().endsWith('.import.scss') &&
+            !url.toString().endsWith('.import.sass')) {
+          _libraryUrl ??= url;
+        }
 
         visitStylesheet(result.item2);
         var importSource = ImportSource(url, import);

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -20,7 +20,8 @@ import 'patch.dart';
 /// Returns the default namespace for a use rule with [path].
 String namespaceForPath(String path) {
   // TODO(jathak): Confirm that this is a valid Sass identifier
-  return path.split('/').last.split('.').first;
+  var basename = path.split('/').last.split('.').first;
+  return basename.startsWith('_') ? basename.substring(1) : basename;
 }
 
 /// Creates a patch that adds [text] immediately before [node].

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -202,6 +202,10 @@ Uri getImportOnlyUrl(Uri url) {
   return url.resolve('$basename.import.$extension');
 }
 
+/// Returns true if [url] is an import-only file.
+bool isImportOnlyFile(Uri url) =>
+    url.path.endsWith('.import.scss') || url.path.endsWith('.import.sass');
+
 /// Partitions [iterable] into two lists based on the types of its inputs.
 ///
 /// This asserts that every element in [iterable] is either an `F` or a `G`, and

--- a/test/migrators/module/conflicting_namespaces/import_only.hrx
+++ b/test/migrators/module/conflicting_namespaces/import_only.hrx
@@ -1,0 +1,32 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "a/variables";
+@import "b/variables";
+
+a {
+  color: $a;
+  background: $b;
+}
+
+<==> input/a/_variables.scss
+$a: blue;
+
+<==> input/a/_variables.import.scss
+@forward "variables";
+
+<==> input/b/_variables.scss
+$b: green;
+
+<==> input/b/_variables.import.scss
+@forward "variables";
+
+<==> output/entrypoint.scss
+@use "a/variables" as a-variables;
+@use "b/variables" as b-variables;
+
+a {
+  color: a-variables.$a;
+  background: b-variables.$b;
+}

--- a/test/migrators/module/conflicting_namespaces/import_only_load_path.hrx
+++ b/test/migrators/module/conflicting_namespaces/import_only_load_path.hrx
@@ -1,0 +1,32 @@
+<==> arguments
+--migrate-deps --load-path load-path
+
+<==> input/entrypoint.scss
+@import "a/variables";
+@import "b/variables";
+
+a {
+  color: $a;
+  background: $b;
+}
+
+<==> input/load-path/a/_variables.scss
+$a: blue;
+
+<==> input/load-path/a/_variables.import.scss
+@forward "variables";
+
+<==> input/load-path/b/_variables.scss
+$b: green;
+
+<==> input/load-path/b/_variables.import.scss
+@forward "variables";
+
+<==> output/entrypoint.scss
+@use "a/variables" as a-variables;
+@use "b/variables" as b-variables;
+
+a {
+  color: a-variables.$a;
+  background: b-variables.$b;
+}

--- a/test/migrators/module/partial_migration/implicit_dependency.hrx
+++ b/test/migrators/module/partial_migration/implicit_dependency.hrx
@@ -1,0 +1,31 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "direct";
+
+a {
+  b: $direct;
+  c: $indirect;
+}
+
+<==> input/_direct.scss
+@use "indirect";
+
+$direct: indirect.$indirect + 1;
+
+<==> input/_direct.import.scss
+@forward "direct";
+@forward "indirect";
+
+<==> input/_indirect.scss
+$indirect: 2;
+
+<==> output/entrypoint.scss
+@use "direct";
+@use "indirect";
+
+a {
+  b: direct.$direct;
+  c: indirect.$indirect;
+}

--- a/test/migrators/module/partial_migration/implicit_dependency_layered.hrx
+++ b/test/migrators/module/partial_migration/implicit_dependency_layered.hrx
@@ -1,0 +1,39 @@
+<==> arguments
+--migrate-deps
+
+<==> README.md
+This test ensures that `@forward` rules in an import-only file is bypassed,
+but that `@forward` rules in regular files are still respected (so `$upstream`
+is part of the `indirect` module from the entrypoint's perspective).
+
+<==> input/entrypoint.scss
+@import "direct";
+
+a {
+  b: $direct;
+  c: $upstream;
+}
+
+<==> input/_direct.scss
+@use "indirect";
+
+$direct: indirect.$upstream + 1;
+
+<==> input/_direct.import.scss
+@forward "direct";
+@forward "indirect";
+
+<==> input/_indirect.scss
+@forward "upstream";
+
+<==> input/_upstream.scss
+$upstream: 2;
+
+<==> output/entrypoint.scss
+@use "direct";
+@use "indirect";
+
+a {
+  b: direct.$direct;
+  c: indirect.$upstream;
+}

--- a/test/migrators/module/partial_migration/implicit_dependency_prefixed.hrx
+++ b/test/migrators/module/partial_migration/implicit_dependency_prefixed.hrx
@@ -1,0 +1,34 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "direct";
+
+a {
+  b: $direct-variable;
+  c: $indirect-variable;
+}
+
+<==> input/_direct.scss
+@use "indirect";
+
+$variable: indirect.$variable + 1;
+
+<==> input/_direct.import.scss
+@forward "direct" as direct-*;
+@forward "indirect" as indirect-*;
+
+<==> input/_indirect.scss
+$variable: 1;
+
+<==> input/_indirect.import.scss
+@forward "indirect" as indirect-*;
+
+<==> output/entrypoint.scss
+@use "direct";
+@use "indirect";
+
+a {
+  b: direct.$variable;
+  c: indirect.$variable;
+}


### PR DESCRIPTION
Fixes #129.

The migrator should now correctly identify forwards that are missing when switching from an import-only file to the regular file.

This will allow libraries to require stricter dependencies for their users when those users migrate to the module system, without breaking `@import` users that depend on implicit dependencies.

To make this work, the `sourceUrl` of `MemberDeclaration` now ignores import-only files, so if a member is forwarded through an import-only file, its `sourceUrl` will be the URL will be the file being forwarded, even if it's not the regular file that corresponds to that import-only file.

This also adds `ImportOnlySource`, which is like a `ForwardSource` but for forwards within import-only files. `ImportSource` can now be created either from a real `@import` rule, or from an `ImportOnlySource`.