### PR TITLE
Fix bugs necessary for mdc-web migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.1.1
+
+### Module Migrator
+
+* When using `--forward=import-only`, `@forward` rules in an import-only file
+  are now sorted with the regular file last, allowing variables in indirect
+  dependencies to be configured.
+
+* Fixes a bug where some references weren't renamed if a variable is declared
+  twice when using `--remove-prefix`.
+
 ## 1.1.0
 
 * Add support for glob inputs on the command line.

--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -119,8 +119,10 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
   /// Visits the stylesheet at [dependency], resolved based on the current
   /// stylesheet's URL and importer.
   @protected
-  void visitDependency(Uri dependency, FileSpan context) {
-    var result = importCache.import(dependency, _importer, _currentUrl);
+  void visitDependency(Uri dependency, FileSpan context,
+      {bool forImport = false}) {
+    var result = importCache.import(dependency,
+        baseImporter: _importer, baseUrl: _currentUrl, forImport: forImport);
     if (result != null) {
       // If [dependency] comes from a non-relative import, don't migrate it,
       // because it's likely to be outside the user's repository and may even be
@@ -163,7 +165,7 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
     if (migrateDependencies) {
       for (var import in node.imports) {
         if (import is DynamicImport) {
-          visitDependency(Uri.parse(import.url), import.span);
+          visitDependency(Uri.parse(import.url), import.span, forImport: true);
         }
       }
     }

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -75,6 +75,8 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   Map<Uri, String> run() {
     var allMigrated = <Uri, String>{};
     var importer = FilesystemImporter('.');
+    var importCache = ImportCache([NodeModulesImporter()],
+        loadPaths: globalResults['load-path']);
 
     var entrypoints = [
       for (var argument in argResults.rest)
@@ -82,9 +84,8 @@ abstract class Migrator extends Command<Map<Uri, String>> {
           if (entry is File) entry.path
     ];
     for (var entrypoint in entrypoints) {
-      var importCache = ImportCache([NodeModulesImporter()],
-          loadPaths: globalResults['load-path']);
-      var tuple = importCache.import(Uri.parse(entrypoint), importer);
+      var tuple =
+          importCache.import(Uri.parse(entrypoint), baseImporter: importer);
       if (tuple == null) {
         throw MigrationException("Could not find Sass file at '$entrypoint'.");
       }

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -296,7 +296,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
             _absoluteUrlToDependency(entry.key, relativeTo: importOnlyUrl)
                 .item1,
             entry.value)
-    ];//..sort((a, b) => a.item2.compareTo(b.item2));
+    ];
     var forwardLines = [
       for (var tuple in tuples)
         ..._forwardRulesForShown(tuple.item1, tuple.item2, tuple.item3,

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -296,12 +296,12 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
             _absoluteUrlToDependency(entry.key, relativeTo: importOnlyUrl)
                 .item1,
             entry.value)
-    ]..sort((a, b) => a.item2.compareTo(b.item2));
+    ];//..sort((a, b) => a.item2.compareTo(b.item2));
     var forwardLines = [
-      ...entrypointForwards,
       for (var tuple in tuples)
         ..._forwardRulesForShown(tuple.item1, tuple.item2, tuple.item3,
-            hiddenByUrl[tuple.item1] ?? {})
+            hiddenByUrl[tuple.item1] ?? {}),
+      ...entrypointForwards
     ];
     var semicolon = entrypoint.path.endsWith('.sass') ? '' : ';';
     return forwardLines.join('$semicolon\n') + '$semicolon\n';

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -788,12 +788,8 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (migrateDependencies) visitDependency(parsedUrl, import.span);
     _upstreamStylesheets.remove(currentUrl);
 
-    // Clear the cache for this URL and re-canonicalize it for a `@use` rule,
-    // since it was previously canonicalized for an `@import` rule.
-    // TODO(jathak): Remove this once dart-sass#899 is fixed
-    importCache.clearCanonicalize(parsedUrl);
-    var tuple = inUseRule(
-        () => importCache.canonicalize(parsedUrl, importer, currentUrl));
+    var tuple = importCache.canonicalize(parsedUrl,
+        baseImporter: importer, baseUrl: currentUrl);
 
     // Associate the importer for this URL with the resolved URL so that we can
     // re-use this import URL later on.
@@ -988,7 +984,10 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
         allHidden.add(name);
       }
       var forward = forwardBase + (subprefix.isEmpty ? '' : ' as $subprefix*');
-      if (allHidden.isNotEmpty) forward += ' hide ${allHidden.join(", ")}';
+      if (allHidden.isNotEmpty) {
+        var sorted = allHidden.toList()..sort();
+        forward += ' hide ${sorted.join(", ")}';
+      }
       forwards.add(forward);
     }
     return forwards;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -266,7 +266,7 @@ packages:
       name: sass
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.23.0"
+    version: "1.24.3"
   shelf:
     dependency: transitive
     description:
@@ -336,7 +336,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.19"
+    version: "0.0.20"
   string_scanner:
     dependency: "direct dev"
     description:
@@ -436,4 +436,4 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   node_interop: "^1.0.0"
   node_io: "^1.0.0"
   path: "^1.6.0"
-  sass: "^1.23.0"
+  sass: "^1.24.3"
   source_span: "^1.4.0"
   term_glyph: "^1.1.0"
   tuple: "^1.0.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.1.0
+version: 1.1.1
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator

--- a/test/migrators/module/forward_flag/import_only.hrx
+++ b/test/migrators/module/forward_flag/import_only.hrx
@@ -19,5 +19,5 @@ a {
 }
 
 <==> output/entrypoint.import.scss
-@forward "entrypoint";
 @forward "library";
+@forward "entrypoint";

--- a/test/migrators/module/forward_flag/import_only_multiple_entrypoints.hrx
+++ b/test/migrators/module/forward_flag/import_only_multiple_entrypoints.hrx
@@ -15,8 +15,8 @@ $lib-variable2: 1;
 $variable1: 1 + entrypoint2.$variable2;
 
 <==> output/entrypoint1.import.scss
-@forward "entrypoint1" as lib-*;
 @forward "entrypoint2" as lib-*;
+@forward "entrypoint1" as lib-*;
 
 <==> output/entrypoint2.scss
 $variable2: 1;

--- a/test/migrators/module/forward_flag/import_only_order.hrx
+++ b/test/migrators/module/forward_flag/import_only_order.hrx
@@ -1,0 +1,37 @@
+<==> arguments
+--migrate-deps --forward=import-only
+
+<==> input/entrypoint.scss
+@import "c";
+@import "b";
+
+a {
+  b: $b-variable;
+  c: $c-variable;
+}
+
+<==> input/_b.scss
+$variable: blue !default;
+
+<==> input/_b.import.scss
+@forward "b" as b-*;
+
+<==> input/_c.scss
+$variable: gold !default;
+
+<==> input/_c.import.scss
+@forward "c" as c-*;
+
+<==> output/entrypoint.scss
+@use "c";
+@use "b";
+
+a {
+  b: b.$variable;
+  c: c.$variable;
+}
+
+<==> output/entrypoint.import.scss
+@forward "c" as c-*;
+@forward "b" as b-*;
+@forward "entrypoint";

--- a/test/migrators/module/forward_flag/import_only_prefixed.hrx
+++ b/test/migrators/module/forward_flag/import_only_prefixed.hrx
@@ -16,5 +16,5 @@ $variable: blue;
 $unprefixed: gold;
 
 <==> output/entrypoint.import.scss
-@forward "entrypoint" as lib-*;
 @forward "library" hide $variable;
+@forward "entrypoint" as lib-*;

--- a/test/migrators/module/remove_prefix_flag/multiple_declarations.hrx
+++ b/test/migrators/module/remove_prefix_flag/multiple_declarations.hrx
@@ -1,0 +1,15 @@
+<==> arguments
+--remove-prefix=lib-
+
+<==> input/entrypoint.scss
+$lib-variable: 1;
+$lib-variable: $lib-variable + 2;
+$lib-variable: $lib-variable + 3;
+
+<==> output/entrypoint.scss
+$variable: 1;
+$variable: $variable + 2;
+$variable: $variable + 3;
+
+<==> output/entrypoint.import.scss
+@forward "entrypoint" as lib-*;


### PR DESCRIPTION
This contains two bug fixes that were necessary for material-components/material-components-web#5220:

- Ensure that all references get renamed when a prefix is removed from a variable that's declared multiple times
- Sort the `@forward` rules within import-only files to ensure that configuration via `@import` still works when a library migrates