### PR TITLE
Refactor ModuleMember

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.1.5
+
+### Module Migrator
+
+* Fix a few bugs when migrating files that imported members through multiple
+  layers of import-only files.
+
 ## 1.1.4
 
 ### Module Migrator

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -267,7 +267,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
         prefix = prefixToRemove;
       } else if (declaration is ImportOnlyMemberDeclaration &&
           declaration.importOnlyPrefix != null &&
-                 url == declaration.sourceUrl) {
+          url == declaration.sourceUrl) {
         prefix = declaration.importOnlyPrefix;
       }
       forwardsByUrl

--- a/lib/src/migrators/module/reference_source.dart
+++ b/lib/src/migrators/module/reference_source.dart
@@ -146,14 +146,16 @@ class ForwardSource extends ReferenceSource {
 /// [_ReferenceVisitor] to track sources internally, and should not be present
 /// in the final [sources] property of [References].
 class ImportOnlySource extends ReferenceSource {
-  /// The canonical URL of the import-only file.
+  /// The canonical URL of the outermost import-only file in the member's
+  /// forward chain.
   final Uri url;
 
-  /// The canonical URL of the file forwarded from the import-only file.
+  /// The canonical URL of the outermost non-import-only file in the member's
+  /// forward chain.
   final Uri realSourceUrl;
 
-  /// If [url] is the import-only file for [realSourceUrl], this should be the
-  /// rule URL from the `@import` rule that loaded the import-only file.
+  /// If [url] is the import-only file for [realSourceUrl], this is the text of
+  /// the URL of the `@import` rule that loaded that import-only file.
   ///
   /// Otherwise, this will be null.
   final String originalRuleUrl;

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -477,17 +477,15 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
       ForwardRule forward,
       Uri forwardedUrl,
       Map<String, MemberDeclaration<T>> declarations) {
-    var declaration =
-        MemberDeclaration<T>.forward(forwarding, forward, forwardedUrl);
+    var declaration = MemberDeclaration<T>.forward(forwarding, forward);
     _registerLibraryUrl(declaration);
     var prefix = forward.prefix ?? '';
     declarations['$prefix${forwarding.name}'] = declaration;
 
-    if (forward.span.sourceUrl.path.endsWith('.import.scss') ||
-        forward.span.sourceUrl.path.endsWith('.import.sass')) {
+    if (declaration is ImportOnlyMemberDeclaration<T>) {
       _declarationSources[declaration] = ImportOnlySource(
-          forward.span.sourceUrl,
-          forwardedUrl,
+          declaration.importOnlyUrl,
+          declaration.sourceUrl,
           forward.span.sourceUrl == getImportOnlyUrl(forwardedUrl)
               ? _currentRuleUrl
               : null);
@@ -709,5 +707,5 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   /// Returns true if [declaration] is from a `@forward` rule in the current
   /// stylesheet.
   bool _fromForwardRuleInCurrent(MemberDeclaration declaration) =>
-      declaration.forward != null && declaration.sourceUrl != _currentUrl;
+      declaration.isForwarded && declaration.sourceUrl != _currentUrl;
 }

--- a/lib/src/patch.dart
+++ b/lib/src/patch.dart
@@ -43,7 +43,7 @@ class Patch implements Comparable<Patch> {
         continue;
       }
       if (patch.selection.start.offset < offset) {
-        throw new ArgumentError("Can't apply overlapping patches.");
+        throw ArgumentError("Can't apply overlapping patches.");
       }
       buffer.write(file.getText(offset, patch.selection.start.offset));
       buffer.write(patch.replacement);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.1.4
+version: 1.1.5
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator

--- a/test/migrators/module/partial_migration/multi_layer/no_prefix.hrx
+++ b/test/migrators/module/partial_migration/multi_layer/no_prefix.hrx
@@ -1,0 +1,58 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "midstream";
+
+a {
+  color: $mid-midvar;
+  background: mid-midfn();
+  @include mid-midmix;
+
+  color: $upvar;
+  background: upfn();
+  @include upmix;
+}
+
+<==> input/_midstream.scss
+$midvar: green;
+
+@function midfn() {
+  @return blue;
+}
+
+@mixin midmix {
+  display: block;
+}
+
+<==> input/_midstream.import.scss
+@forward "upstream.import";
+@forward "midstream" as mid-*;
+
+<==> input/_upstream.scss
+$upvar: green;
+
+@function upfn() {
+  @return blue;
+}
+
+@mixin upmix {
+  display: block;
+}
+
+<==> input/_upstream.import.scss
+@forward "upstream";
+
+<==> output/entrypoint.scss
+@use "midstream";
+@use "upstream";
+
+a {
+  color: midstream.$midvar;
+  background: midstream.midfn();
+  @include midstream.midmix;
+
+  color: upstream.$upvar;
+  background: upstream.upfn();
+  @include upstream.upmix;
+}

--- a/test/migrators/module/partial_migration/multi_layer/normal_forward_before.hrx
+++ b/test/migrators/module/partial_migration/multi_layer/normal_forward_before.hrx
@@ -1,0 +1,61 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "downstream";
+
+a {
+  color: $down-downvar;
+  background: down-downfn();
+  @include down-downmix;
+
+  color: $mid-up-upvar;
+  background: mid-up-upfn();
+  @include mid-up-upmix;
+}
+
+<==> input/_downstream.scss
+$downvar: green;
+
+@function downfn() {
+  @return blue;
+}
+
+@mixin downmix {
+  display: block;
+}
+
+<==> input/_downstream.import.scss
+@forward "midstream.import";
+@forward "downstream" as down-*;
+
+<==> input/_midstream.scss
+@forward "upstream" as up-*;
+
+<==> input/_midstream.import.scss
+@forward "midstream" as mid-*;
+
+<==> input/_upstream.scss
+$upvar: green;
+
+@function upfn() {
+  @return blue;
+}
+
+@mixin upmix {
+  display: block;
+}
+
+<==> output/entrypoint.scss
+@use "downstream";
+@use "midstream";
+
+a {
+  color: downstream.$downvar;
+  background: downstream.downfn();
+  @include downstream.downmix;
+
+  color: midstream.$up-upvar;
+  background: midstream.up-upfn();
+  @include midstream.up-upmix;
+}

--- a/test/migrators/module/partial_migration/multi_layer/one_prefix.hrx
+++ b/test/migrators/module/partial_migration/multi_layer/one_prefix.hrx
@@ -1,0 +1,58 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "midstream";
+
+a {
+  color: $mid-midvar;
+  background: mid-midfn();
+  @include mid-midmix;
+
+  color: $up-upvar;
+  background: up-upfn();
+  @include up-upmix;
+}
+
+<==> input/_midstream.scss
+$midvar: green;
+
+@function midfn() {
+  @return blue;
+}
+
+@mixin midmix {
+  display: block;
+}
+
+<==> input/_midstream.import.scss
+@forward "upstream.import";
+@forward "midstream" as mid-*;
+
+<==> input/_upstream.scss
+$upvar: green;
+
+@function upfn() {
+  @return blue;
+}
+
+@mixin upmix {
+  display: block;
+}
+
+<==> input/_upstream.import.scss
+@forward "upstream" as up-*;
+
+<==> output/entrypoint.scss
+@use "midstream";
+@use "upstream";
+
+a {
+  color: midstream.$midvar;
+  background: midstream.midfn();
+  @include midstream.midmix;
+
+  color: upstream.$upvar;
+  background: upstream.upfn();
+  @include upstream.upmix;
+}

--- a/test/migrators/module/partial_migration/multi_layer/two_prefixes.hrx
+++ b/test/migrators/module/partial_migration/multi_layer/two_prefixes.hrx
@@ -1,0 +1,58 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "midstream";
+
+a {
+  color: $mid-midvar;
+  background: mid-midfn();
+  @include mid-midmix;
+
+  color: $up2-up-upvar;
+  background: up2-up-upfn();
+  @include up2-up-upmix;
+}
+
+<==> input/_midstream.scss
+$midvar: green;
+
+@function midfn() {
+  @return blue;
+}
+
+@mixin midmix {
+  display: block;
+}
+
+<==> input/_midstream.import.scss
+@forward "upstream.import" as up2-*;
+@forward "midstream" as mid-*;
+
+<==> input/_upstream.scss
+$upvar: green;
+
+@function upfn() {
+  @return blue;
+}
+
+@mixin upmix {
+  display: block;
+}
+
+<==> input/_upstream.import.scss
+@forward "upstream" as up-*;
+
+<==> output/entrypoint.scss
+@use "midstream";
+@use "upstream";
+
+a {
+  color: midstream.$midvar;
+  background: midstream.midfn();
+  @include midstream.midmix;
+
+  color: upstream.$upvar;
+  background: upstream.upfn();
+  @include upstream.upmix;
+}

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -89,7 +89,8 @@ void ensureExecutableUpToDate() {
 ///
 /// If [ifExists] is `true`, this won't throw an error if the file in question
 /// doesn't exist.
-void _ensureUpToDate(String path, String commandToRun, {bool ifExists: false}) {
+void _ensureUpToDate(String path, String commandToRun,
+    {bool ifExists = false}) {
   // Ensure path is relative so the error messages are more readable.
   path = p.relative(path);
   if (!File(path).existsSync()) {


### PR DESCRIPTION
This shrinks the API surface and clarifies exactly which URLs come
from where. It also creates a type distinction for import-only
members, so that their attributes can only be accessed when they're
known to be valid.

This in turn fixes a few bugs with modules that were forwarded through
multiple layers of import-only files.