### PR TITLE
Stop building 32-bit packages for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -115,15 +115,3 @@ jobs:
       skip_cleanup: true
       on: {tags: true}
 
-  # Deploy to Chocolatey.
-  - name: Chocolatey
-    if: *deploy-if
-    env:
-      # CHOCO_TOKEN="..."
-      - secure: "PoJPDMyDdLHWq5TVEeZm+mQRFpkpg2/r0DiVLP1hXiDmT5ax9JlbLnxOQs0/pzcm263LDoyD1JJWcyAJ6fJTZlrDoKK3doNyIgkCo3dk9pX0FU0N0XLWfnG88rjVS0/W61muu6syfYj6b/ZJwF8Eay8wHDryQaQmgiZ2xTtqJYmPBoQ2nMxTgnlkuqboJc1/GUsNgI1QnNlejN57frp5hZy9/jmTPVFkMsK6BJJtNQ7akxqTPIz+itRrnlxYI6vCeHIie7qsK5jwlhkkzuaOD8l5mYUNLDiBxdoPknSwwsHsRNw/CsBQxxyJ0zwCFQKojgN4TSsz2mklEt3+5j7Gq4UVMnBAi/vPwfdgxpDx8XXbYnECrtyV0e9PyTursrCxYw+Fq6mHmLTFNtQVTX4SvbY01NhaiaS4El8efctIF6by1JfcKYGrcGbn+kwwKl/2YOyctnrsVfLw6qwRE7MhpxIYmpQgajQcu5b/XSW1bLjSqj/9sVypnMQus2fiNKh5eMpZn/FXD2APiI3oQp/z7FVJTfRvF+2FPqN6TVej82zJ0SBiTedMF3EYjfeL2oScFar8QCI2z7jABqoeC3g34bOzqPOXRc7SMDac+MrBrTyF1nRwXz1aGlK4zMALbTGul7yqbxehfs3wBd6Sr5YmljnUksZZ2g25uwFJp2w5TgM="
-    script: skip
-    deploy:
-      provider: script
-      script: pub run grinder update-chocolatey
-      skip_cleanup: true
-      on: {tags: true}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -86,7 +86,7 @@ packages:
     source: hosted
     version: "0.13.9"
   crypto:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: crypto
       url: "https://pub.dartlang.org"
@@ -149,7 +149,7 @@ packages:
     source: hosted
     version: "0.3.4"
   js:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: js
       url: "https://pub.dartlang.org"

--- a/tool/grind/standalone.dart
+++ b/tool/grind/standalone.dart
@@ -51,7 +51,7 @@ package() async {
   var client = http.Client();
   await Future.wait(["linux", "macos", "windows"].expand((os) => [
         _buildPackage(client, os, x64: true),
-        _buildPackage(client, os, x64: false)
+        if (os != "macos") _buildPackage(client, os, x64: false)
       ]));
   client.close();
 }


### PR DESCRIPTION
32-bit Dart SDKs for macOS no longer exist, so the deploy script attempting to download them was causing the entire GitHub release to fail.