### PR TITLE
`--remove-prefix` fixes for private members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.3.1
+
+### Module Migrator
+
+* Prefixes will now be removed from private members (e.g. a variable
+  `$_lib-variable` will be renamed to `$_variable` when `--remove-prefix=lib-`
+  is passed).
+
+* Fix a bug where private members would be incorrectly added to `hide` clauses
+  in generated import-only files.
+
 ## 1.3.0
 
 ### Namespace Migrator

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -245,9 +245,11 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     var hiddenByUrl = <Uri, Set<MemberDeclaration>>{};
     for (var declaration in references.globalDeclarations) {
       var private = declaration.name.startsWith('-');
+
       // Whether this member will be exposed by the regular entrypoint.
-      var visibleAtEntrypoint = declaration.sourceUrl == entrypoint ||
-          (_shouldForward(declaration.name) && !private);
+      var visibleAtEntrypoint = (declaration.sourceUrl == entrypoint ||
+              _shouldForward(declaration.name)) &&
+          !private;
       // Whether this member should be exposed by the import-only file for the
       // entrypoint.
       var shouldBeVisible =
@@ -1147,7 +1149,11 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
     if (declaration == null) return;
     if (renamedMembers.containsKey(declaration)) {
       var newName = renamedMembers[declaration];
-      if (declaration.name.endsWith(newName)) {
+      if (newName.startsWith('-') &&
+          declaration.name.endsWith(newName.substring(1))) {
+        addPatch(patchDelete(span,
+            start: 1, end: declaration.name.length - newName.length + 1));
+      } else if (declaration.name.endsWith(newName)) {
         addPatch(
             patchDelete(span, end: declaration.name.length - newName.length));
       } else {
@@ -1167,8 +1173,11 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   ///
   /// Otherwise, returns [name] unaltered.
   String _unprefix(String name) {
-    var prefix = _prefixFor(name);
-    return prefix == null ? name : name.substring(prefix.length);
+    var unprivateName = name.startsWith('-') ? name.substring(1) : name;
+    var prefix = _prefixFor(unprivateName);
+    if (prefix == null) return name;
+    return (name == unprivateName ? '' : '-') +
+        unprivateName.substring(prefix.length);
   }
 
   /// Returns the namespace that built-in module [module] is loaded under.

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -247,9 +247,9 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
       var private = declaration.name.startsWith('-');
 
       // Whether this member will be exposed by the regular entrypoint.
-      var visibleAtEntrypoint = (declaration.sourceUrl == entrypoint ||
-              _shouldForward(declaration.name)) &&
-          !private;
+      var visibleAtEntrypoint = !private &&
+          (declaration.sourceUrl == entrypoint ||
+              _shouldForward(declaration.name));
       // Whether this member should be exposed by the import-only file for the
       // entrypoint.
       var shouldBeVisible =
@@ -1173,11 +1173,11 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
   ///
   /// Otherwise, returns [name] unaltered.
   String _unprefix(String name) {
-    var unprivateName = name.startsWith('-') ? name.substring(1) : name;
+    var isPrivate = name.startsWith('-');
+    var unprivateName = isPrivate ? name.substring(1) : name;
     var prefix = _prefixFor(unprivateName);
     if (prefix == null) return name;
-    return (name == unprivateName ? '' : '-') +
-        unprivateName.substring(prefix.length);
+    return (isPrivate ? '-' : '') + unprivateName.substring(prefix.length);
   }
 
   /// Returns the namespace that built-in module [module] is loaded under.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.3.0
+version: 1.3.1
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator

--- a/test/migrators/module/remove_prefix_flag/unprefixed_members.hrx
+++ b/test/migrators/module/remove_prefix_flag/unprefixed_members.hrx
@@ -6,12 +6,16 @@ $lib-a: 1;
 $lib-b: 2;
 $c: 3;
 $d: 4;
+$_e: 5;
+$_lib-f: 6;
 
 <==> output/entrypoint.scss
 $a: 1;
 $b: 2;
 $c: 3;
 $d: 4;
+$_e: 5;
+$_f: 6;
 
 <==> output/entrypoint.import.scss
 @forward "entrypoint" hide $a, $b;


### PR DESCRIPTION
Fixes #169.

Unnecessary hide clauses will no longer be added to import-only files.
Prefixes can now also be removed from private members.