### PR TITLE
Fix a crash with orphan import-only files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.3.4
+
+### Module Migrator
+
+* Fix a crash when resolving references to orphan import-only files in a
+  different directory from the file depending on them.
+
 ## 1.3.3
 
 * No user-visible changes.

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -761,13 +761,18 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
 
     for (var import in dynamicImports) {
       var ruleUrl = import.url;
-      var canonicalImport = importCache
-          .canonicalize(Uri.parse(ruleUrl),
-              baseImporter: importer, forImport: true)
-          ?.item2;
+      var tuple = importCache.canonicalize(Uri.parse(ruleUrl),
+          baseImporter: importer, forImport: true);
+      var canonicalImport = tuple?.item2;
       if (references.orphanImportOnlyFiles.containsKey(canonicalImport)) {
-        ruleUrl =
-            references.orphanImportOnlyFiles[canonicalImport]?.url.toString();
+        var url = references.orphanImportOnlyFiles[canonicalImport]?.url;
+        if (url != null) {
+          var canonicalRedirect = importCache
+              .canonicalize(url,
+                  baseImporter: tuple.item1, baseUrl: canonicalImport)
+              .item2;
+          ruleUrl = _absoluteUrlToDependency(canonicalRedirect).item1;
+        }
       }
 
       if (ruleUrl != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.3.3
+version: 1.3.4
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator

--- a/test/migrators/module/partial_migration/changed_path_relative.hrx
+++ b/test/migrators/module/partial_migration/changed_path_relative.hrx
@@ -1,0 +1,22 @@
+<==> arguments
+--migrate-deps
+
+<==> input/entrypoint.scss
+@import "some/library/old";
+
+a {
+  b: $lib-variable;
+}
+
+<==> input/some/library/_old.import.scss
+@forward "new" as lib-*;
+
+<==> input/some/library/_new.scss
+$variable: green;
+
+<==> output/entrypoint.scss
+@use "some/library/new";
+
+a {
+  b: new.$variable;
+}


### PR DESCRIPTION
Previously we just used the rule URL from the orphan import-only's last
`@forward` rule directly, but that only works when that URL is relative
to a load path or the orphan is in the same directory as the file
depending on it.

We now build a new dependency URL after resolving the old rule URL into
its canonical form.