### PR TITLE
Fix crash on Node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         with: {node-version: "${{ matrix.node_version }}"}
       - run: npm install
       - run: dart pub run grinder pkg-npm-dev
+      - name: Run tests
+        run: dart pub run test -t node -r expanded
 
   static_analysis:
     name: Static analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.9
+
+* Fix crash when running on Node.
+
 ## 1.3.8
 
 * No user-visible changes.

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -4,8 +4,10 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+import 'package:file/file.dart';
 import 'package:js/js.dart';
 import 'package:node_interop/node.dart';
+import 'package:node_io/node_io.dart';
 
 // Node seems to support ANSI escapes on all terminals.
 //
@@ -15,3 +17,5 @@ import 'package:node_interop/node.dart';
 external bool get supportsAnsiEscapes;
 
 void printStderr(Object message) => process.stderr.write("$message\n");
+
+FileSystem get fileSystem => nodeFileSystem;

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -6,6 +6,9 @@
 
 import 'dart:io';
 
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+
 /// Whether this process is connected to a terminal that supports ANSI escape
 /// sequences.
 bool get supportsAnsiEscapes {
@@ -19,3 +22,6 @@ bool get supportsAnsiEscapes {
 
 /// Prints [message] to standard error, followed by a newline.
 void printStderr(Object message) => stderr.writeln(message);
+
+/// The local filesystem.
+FileSystem get fileSystem => const LocalFileSystem();

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -14,7 +14,6 @@ import 'package:sass/src/import_cache.dart';
 
 import 'package:args/command_runner.dart';
 import 'package:glob/glob.dart';
-import 'package:glob/list_local_fs.dart';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:sass_migrator/src/util/node_modules_importer.dart';
@@ -82,7 +81,7 @@ abstract class Migrator extends Command<Map<Uri, String>> {
 
     var entrypoints = [
       for (var argument in argResults!.rest)
-        for (var entry in Glob(argument).listSync())
+        for (var entry in Glob(argument).listFileSystemSync(fileSystem))
           if (entry is File) entry.path
     ];
     for (var entrypoint in entrypoints) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.3.8
+version: 1.3.9
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator
@@ -11,6 +11,7 @@ dependencies:
   args: ^2.1.0
   charcode: ^1.2.0
   collection: ^1.15.0
+  file: ^6.1.0
   glob: ^2.0.1
   js: ^0.6.3
   meta: ^1.3.0


### PR DESCRIPTION
Fixes #184.

It looks like glob 2.x stopped supporting Node natively, so we need to pass in the correct filesystem ourselves. The GitHub actions never actually ran the Node tests, so I missed the error when migrating.