### PR TITLE
Allow non-glob file path arguments containing glob syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.5
+
+* Glob syntax will no longer be resolved if a file with that literal name
+  exists.
+
 ## 1.4.4
 
 ### Division Migrator

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -81,7 +81,7 @@ abstract class Migrator extends Command<Map<Uri, String>> {
 
     var entrypoints = [
       for (var argument in argResults!.rest)
-        if (FileSystemEntity.typeSync(argument) == FileSystemEntityType.FILE) argument
+        if (File(argument).existsSync()) argument
         else
           for (var entry in Glob(argument).listFileSystemSync(fileSystem))
             if (entry is File) entry.path

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -81,8 +81,10 @@ abstract class Migrator extends Command<Map<Uri, String>> {
 
     var entrypoints = [
       for (var argument in argResults!.rest)
-        for (var entry in Glob(argument).listFileSystemSync(fileSystem))
-          if (entry is File) entry.path
+        if (FileSystemEntity.typeSync(argument) == FileSystemEntityType.FILE) argument
+        else
+          for (var entry in Glob(argument).listFileSystemSync(fileSystem))
+            if (entry is File) entry.path
     ];
     for (var entrypoint in entrypoints) {
       var tuple =

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -81,7 +81,8 @@ abstract class Migrator extends Command<Map<Uri, String>> {
 
     var entrypoints = [
       for (var argument in argResults!.rest)
-        if (File(argument).existsSync()) argument
+        if (File(argument).existsSync())
+          argument
         else
           for (var entry in Glob(argument).listFileSystemSync(fileSystem))
             if (entry is File) entry.path

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.4.4
+version: 1.4.5
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator

--- a/test/cli_dart_test.dart
+++ b/test/cli_dart_test.dart
@@ -64,6 +64,18 @@ void main() {
     ]).validate();
   });
 
+  test("allows non-glob file arguments containing glob syntax", () async {
+    await d.dir('[dir]', [
+      d.file("test.scss", "a {b: (1 / 2)}")
+    ]).create();
+
+    await (await runMigrator(["division", "[dir]/test.scss"])).shouldExit(0);
+
+    await d.dir('[dir]', [
+      d.file("test.scss", '@use "sass:math";\n\na {b: math.div(1, 2)}')
+    ]).validate();
+  });
+
   group("with --dry-run", () {
     test("prints the name of a file that would be migrated", () async {
       await d.file("test.scss", "a {b: abs(-1)}").create();

--- a/test/cli_dart_test.dart
+++ b/test/cli_dart_test.dart
@@ -65,9 +65,7 @@ void main() {
   });
 
   test("allows non-glob file arguments containing glob syntax", () async {
-    await d.dir('[dir]', [
-      d.file("test.scss", "a {b: (1 / 2)}")
-    ]).create();
+    await d.dir('[dir]', [d.file("test.scss", "a {b: (1 / 2)}")]).create();
 
     await (await runMigrator(["division", "[dir]/test.scss"])).shouldExit(0);
 


### PR DESCRIPTION
Available examples and documentation don't specify that file path arguments should be passed in as quoted glob patterns to avoid processing by shells, rather than being able to be expanded by the shell before execution. In many cases this is fine, as patterns not containing glob pattern syntax will be handled as expected. However, if I pass a file like `assets/scss/pages/sport/\[sport\]/roster.module.scss` without quoting it, or use a matching glob pattern like `assets/**/*.scss` (also not quoted), expanded by a shell with globstar enabled, an error is thrown about `assets/scss/pages/sport/s` not existing.

With my change, if a passed argument is an existing file, it will be used without trying to handle it as a glob pattern.