### PR TITLE
Use the new AST interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.2
+
+* No user-visible changes.
+
 ## 1.5.1
 
 ### Division Migrator

--- a/lib/src/exception.dart
+++ b/lib/src/exception.dart
@@ -17,10 +17,13 @@ class MigrationException implements Exception {
   String toString() => "Error: $message";
 }
 
+// TODO(jathak): Stop extending [SassException] here.
+// ignore_for_file: subtype_of_sealed_class
+
 /// A [MigrationException] that has source span information associated with it.
-//
-// This extends [SassException] to ensure that migrator exceptions are formatted
-// the same way as the syntax errors Sass throws.
+///
+/// This extends [SassException] to ensure that migrator exceptions are
+/// formatted the same way as the syntax errors Sass throws.
 class MigrationSourceSpanException extends SassException
     implements MigrationException {
   MigrationSourceSpanException(String message, FileSpan span)

--- a/lib/src/migration_visitor.dart
+++ b/lib/src/migration_visitor.dart
@@ -170,7 +170,7 @@ abstract class MigrationVisitor extends RecursiveAstVisitor {
     if (migrateDependencies) {
       for (var import in node.imports) {
         if (import is DynamicImport) {
-          visitDependency(Uri.parse(import.url), import.span, forImport: true);
+          visitDependency(import.url, import.span, forImport: true);
         }
       }
     }

--- a/lib/src/migrators/division.dart
+++ b/lib/src/migrators/division.dart
@@ -163,7 +163,6 @@ class _DivisionMigrationVisitor extends MigrationVisitor {
   /// for new-syntax color functions.
   @override
   void visitFunctionExpression(FunctionExpression node) {
-    visitInterpolation(node.name);
     if (_tryColorFunction(node)) return;
     visitArgumentInvocation(node.arguments);
   }
@@ -226,7 +225,7 @@ class _DivisionMigrationVisitor extends MigrationVisitor {
   /// Migrates [node] and returns true if it is a new-syntax color function or
   /// returns false if it is any other function.
   bool _tryColorFunction(FunctionExpression node) {
-    if (!["rgb", "rgba", "hsl", "hsla"].contains(node.name.asPlain)) {
+    if (!["rgb", "rgba", "hsl", "hsla"].contains(node.name)) {
       return false;
     }
 

--- a/lib/src/migrators/module/member_declaration.dart
+++ b/lib/src/migrators/module/member_declaration.dart
@@ -14,10 +14,7 @@ import 'package:path/path.dart' as p;
 import '../../utils.dart';
 
 /// A wrapper class for nodes that declare a variable, function, or mixin.
-///
-/// The member this class wraps will always be a [VariableDeclaration],
-/// an [Argument], a [MixinRule], or a [FunctionRule].
-class MemberDeclaration<T extends SassNode> {
+class MemberDeclaration<T extends SassDeclaration> {
   /// The original definition of the member, after all `@forward` rules have
   /// been resolved.
   final T member;
@@ -46,27 +43,13 @@ class MemberDeclaration<T extends SassNode> {
 
   /// Creates a MemberDefinition for a [member] that was loaded from the same
   /// module it was defined.
-  ///
-  /// The [member] must be a [VariableDeclaration], [Argument], [MixinRule], or
-  /// [FunctionRule].
   MemberDeclaration(T member)
-      : this._(member, () {
-          if (member is VariableDeclaration) return member.name;
-          if (member is Argument) return member.name;
-          if (member is MixinRule) return member.name;
-          if (member is FunctionRule) return member.name;
-          throw ArgumentError(
-              "MemberDefinition must contain a VariableDeclaration, Argument, "
-              "MixinRule, or FunctionRule");
-        }(), member.span.sourceUrl!);
+      : this._(member, member.name, member.span.sourceUrl!);
 
   /// Creates a MemberDefinition for a member that was forwarded through at
   /// least one non-import-only module.
   ///
   /// The [forwarded] member is the member loaded by [forward].
-  ///
-  /// The [member] must be a [VariableDeclaration], [Argument], [MixinRule], or
-  /// [FunctionRule].
   ///
   /// If [forward] comes from an import-only file, this returns an
   /// [ImportOnlyMemberDeclaration].
@@ -104,7 +87,7 @@ class MemberDeclaration<T extends SassNode> {
 }
 
 /// A declaration for a member forwarded through an import-only file.
-class ImportOnlyMemberDeclaration<T extends SassNode>
+class ImportOnlyMemberDeclaration<T extends SassDeclaration>
     extends MemberDeclaration<T> {
   /// The prefix added to [name] by forwards through import-only files.
   final String importOnlyPrefix;

--- a/lib/src/migrators/module/reference_source.dart
+++ b/lib/src/migrators/module/reference_source.dart
@@ -31,7 +31,7 @@ class ImportSource extends ReferenceSource {
 
   /// The URL of the `@import` rule that loaded this member, or null if this
   /// is for an indirect dependency forwarded in an import-only file.
-  final String? originalRuleUrl;
+  final Uri? originalRuleUrl;
 
   /// Creates an [ImportSource] for [url] from [import].
   ///
@@ -158,7 +158,7 @@ class ImportOnlySource extends ReferenceSource {
   /// the URL of the `@import` rule that loaded that import-only file.
   ///
   /// Otherwise, this will be null.
-  final String? originalRuleUrl;
+  final Uri? originalRuleUrl;
 
   ImportOnlySource(this.url, this.realSourceUrl, this.originalRuleUrl);
 

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -295,9 +295,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
     var functions = _unresolvedReferences.keys.whereType<FunctionExpression>();
     for (var function in functions) {
       if (_isCssCompatibilityOverload(function)) continue;
-      var name = function.name;
-      if (name == null) continue;
-      var module = builtInFunctionModules[name];
+      var module = builtInFunctionModules[function.name];
       if (module != null) _sources[function] = BuiltInSource(module);
     }
   }
@@ -566,9 +564,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
         _linkUnresolvedReference(
             reference, reference.name, scope.mixins, _mixins);
       } else if (reference is FunctionExpression) {
-        var name = reference.name;
-        if (name == null) continue;
-        if (name == 'get-function') {
+        if (reference.name == 'get-function') {
           var nameExpression = getStaticNameForGetFunctionCall(reference);
           if (nameExpression == null) continue;
           var staticName = nameExpression.text.replaceAll('_', '-');
@@ -577,7 +573,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
               trackSources: false);
         } else {
           _linkUnresolvedReference(
-              reference, name, scope.functions, _functions);
+              reference, reference.name, scope.functions, _functions);
         }
       }
     }

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -35,8 +35,7 @@ class References {
   /// An unmodifiable map between variable references and their declarations.
   ///
   /// Each value in this map must be a [VariableDeclaration] or an [Argument].
-  final BidirectionalMap<VariableExpression,
-      MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >> variables;
+  final BidirectionalMap<VariableExpression, MemberDeclaration> variables;
 
   /// An unmodifiable map between variable reassignments and the original
   /// declaration they override.
@@ -46,16 +45,14 @@ class References {
   ///
   /// Each value in this map must be a [VariableDeclaration] or an [Argument].
   final BidirectionalMap<MemberDeclaration<VariableDeclaration>,
-          MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>
-      variableReassignments;
+      MemberDeclaration> variableReassignments;
 
   /// An unmodifiable map from variable declarations with the `!default` flag to
   /// the declaration they would override were it not for that flag.
   ///
   /// This only includes `!default` declarations for variables that already
   /// exist.
-  final Map<MemberDeclaration<VariableDeclaration>,
-          MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>
+  final Map<MemberDeclaration<VariableDeclaration>, MemberDeclaration>
       defaultVariableDeclarations;
 
   /// An unmodifiable map between mixin references and their declarations.
@@ -88,7 +85,7 @@ class References {
   /// This includes references to built-in functions, but it does not include
   /// functions referenced within `get-function` calls (those nodes instead
   /// map to the [ReferenceSource] for the `sass:meta` module).
-  final Map<SassNode, ReferenceSource> sources;
+  final Map<SassReference, ReferenceSource> sources;
 
   /// Map of import-only files that do not directly depend on their regular
   /// counterparts to the last forward appearing within it (or null, if no
@@ -100,7 +97,7 @@ class References {
       variables.values.followedBy(mixins.values).followedBy(functions.values);
 
   /// Returns all references to [declaration].
-  Iterable<SassNode> referencesTo(MemberDeclaration declaration) {
+  Iterable<SassReference> referencesTo(MemberDeclaration declaration) {
     if (declaration is MemberDeclaration<FunctionRule>) {
       return functions
           .keysForValue(declaration)
@@ -138,14 +135,11 @@ class References {
   }
 
   References._(
-      BidirectionalMap<VariableExpression,
-              MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>
-          variables,
+      BidirectionalMap<VariableExpression, MemberDeclaration> variables,
       BidirectionalMap<MemberDeclaration<VariableDeclaration>,
-              MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>
+              MemberDeclaration>
           variableReassignments,
-      Map<MemberDeclaration<VariableDeclaration>,
-              MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>
+      Map<MemberDeclaration<VariableDeclaration>, MemberDeclaration>
           defaultVariableDeclarations,
       BidirectionalMap<IncludeRule, MemberDeclaration<MixinRule>> mixins,
       BidirectionalMap<FunctionExpression, MemberDeclaration<FunctionRule>>
@@ -154,7 +148,7 @@ class References {
           getFunctionReferences,
       Set<MemberDeclaration> globalDeclarations,
       Map<MemberDeclaration, Set<Uri>> libraries,
-      Map<SassNode, ReferenceSource> sources,
+      Map<SassReference, ReferenceSource> sources,
       Map<Uri, ForwardRule?> orphanImportOnlyFiles)
       : variables = UnmodifiableBidirectionalMapView(variables),
         variableReassignments =
@@ -182,13 +176,11 @@ class References {
 
 /// A visitor that builds a References object.
 class _ReferenceVisitor extends RecursiveAstVisitor {
-  final _variables = BidirectionalMap<VariableExpression,
-      MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>();
+  final _variables = BidirectionalMap<VariableExpression, MemberDeclaration>();
   final _variableReassignments = BidirectionalMap<
-      MemberDeclaration<VariableDeclaration>,
-      MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>();
-  final _defaultVariableDeclarations = <MemberDeclaration<VariableDeclaration>,
-      MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>{};
+      MemberDeclaration<VariableDeclaration>, MemberDeclaration>();
+  final _defaultVariableDeclarations =
+      <MemberDeclaration<VariableDeclaration>, MemberDeclaration>{};
   final _mixins = BidirectionalMap<IncludeRule, MemberDeclaration<MixinRule>>();
   final _functions =
       BidirectionalMap<FunctionExpression, MemberDeclaration<FunctionRule>>();
@@ -196,7 +188,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
       BidirectionalMap<FunctionExpression, MemberDeclaration<FunctionRule>>();
   final _globalDeclarations = <MemberDeclaration>{};
   final _libraries = <MemberDeclaration, Set<Uri>>{};
-  final _sources = <SassNode, ReferenceSource>{};
+  final _sources = <SassReference, ReferenceSource>{};
   final _orphanImportOnlyFiles = <Uri, ForwardRule?>{};
 
   /// The current global scope.
@@ -220,11 +212,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
 
   /// Mapping between member references for which no definition was found and
   /// the scope the reference was contained in.
-  ///
-  /// Each key of this map should be a [VariableExpression], an [IncludeRule],
-  /// or a [FunctionExpression].
-  final _unresolvedReferences =
-      <SassNode /*VariableExpression|IncludeRule|FunctionExpression*/, Scope>{};
+  final _unresolvedReferences = <SassReference, Scope>{};
 
   /// Namespaces present within the current stylesheet.
   ///
@@ -245,7 +233,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   late Uri _currentUrl;
 
   /// The URL of the rule used to load the current stylesheet.
-  String? _currentRuleUrl;
+  Uri? _currentRuleUrl;
 
   /// The importer that's currently being used to resolve relative imports.
   ///
@@ -307,8 +295,8 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
     var functions = _unresolvedReferences.keys.whereType<FunctionExpression>();
     for (var function in functions) {
       if (_isCssCompatibilityOverload(function)) continue;
-      if (function.name.asPlain == null) continue;
-      var name = function.name.asPlain!.replaceAll('_', '-');
+      var name = function.name;
+      if (name == null) continue;
       var module = builtInFunctionModules[name];
       if (module != null) _sources[function] = BuiltInSource(module);
     }
@@ -319,7 +307,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   /// migrated to the module version.
   bool _isCssCompatibilityOverload(FunctionExpression node) {
     var argument = getOnlyArgument(node.arguments);
-    switch (node.name.asPlain) {
+    switch (node.name) {
       case 'grayscale':
       case 'invert':
       case 'opacity':
@@ -365,7 +353,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   void visitImportRule(ImportRule node) {
     super.visitImportRule(node);
     for (var import in node.imports.whereType<DynamicImport>()) {
-      var result = importCache.import(Uri.parse(import.url),
+      var result = importCache.import(import.url,
           baseImporter: _importer, baseUrl: _currentUrl, forImport: true);
       if (result == null) {
         throw MigrationSourceSpanException(
@@ -453,7 +441,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
     var oldLibraryUrl = _libraryUrl;
     _libraryUrl = null;
     var oldRuleUrl = _currentRuleUrl;
-    _currentRuleUrl = ruleUrl.toString();
+    _currentRuleUrl = ruleUrl;
     visitStylesheet(stylesheet);
     _checkUnresolvedReferences(_scope);
     _libraryUrl = oldLibraryUrl;
@@ -512,7 +500,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
 
   /// Forwards [forwarding] into [declarations], adding the forwarded
   /// declaration to [_declarationSources].
-  void _forwardMember<T extends SassNode>(
+  void _forwardMember<T extends SassDeclaration>(
       MemberDeclaration<T> forwarding,
       ForwardRule forward,
       Uri forwardedUrl,
@@ -578,7 +566,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
         _linkUnresolvedReference(
             reference, reference.name, scope.mixins, _mixins);
       } else if (reference is FunctionExpression) {
-        var name = reference.name.asPlain?.replaceAll('_', '-');
+        var name = reference.name;
         if (name == null) continue;
         if (name == 'get-function') {
           var nameExpression = getStaticNameForGetFunctionCall(reference);
@@ -599,7 +587,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
   /// in [references] and removes it from [_unresolvedReferences].
   ///
   /// If [trackSources] is true, this also adds [reference] to [_sources].
-  void _linkUnresolvedReference<T extends SassNode>(
+  void _linkUnresolvedReference<T extends SassReference>(
       T reference,
       String name,
       Map<String, MemberDeclaration> declarations,
@@ -719,17 +707,13 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
       _sources[node] = BuiltInSource(urlForNamespace.path);
       return;
     }
-    var name = node.name.asPlain;
-    if (name == null) return;
-    name = name.replaceAll('_', '-');
-
-    var declaration = _scopeForNamespace(namespace).findFunction(name);
+    var declaration = _scopeForNamespace(namespace).findFunction(node.name);
     if (declaration != null && !_fromForwardRuleInCurrent(declaration)) {
       _functions[node] = declaration;
       _sources[node] = _declarationSources[declaration]!;
       return;
     } else if (namespace == null) {
-      if (name == 'get-function') {
+      if (node.name == 'get-function') {
         _sources[node] = BuiltInSource("meta");
       } else {
         _unresolvedReferences[node] = _scope;
@@ -742,7 +726,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
     if (nameExpression == null) return;
     var moduleExpression = getStaticModuleForGetFunctionCall(node);
     namespace = moduleExpression?.text;
-    name = nameExpression.text.replaceAll('_', '-');
+    var name = nameExpression.text.replaceAll('_', '-');
     declaration = _scopeForNamespace(namespace).findFunction(name);
     if (declaration != null && !_fromForwardRuleInCurrent(declaration)) {
       _getFunctionReferences[node] = declaration;
@@ -753,7 +737,7 @@ class _ReferenceVisitor extends RecursiveAstVisitor {
 
   /// Registers the current library as a location from which [declaration] can
   /// be loaded.
-  void _registerLibraryUrl(MemberDeclaration<SassNode> declaration) {
+  void _registerLibraryUrl(MemberDeclaration declaration) {
     var libraryUrl = _libraryUrl;
     if (libraryUrl == null) return;
     _libraries.putIfAbsent(declaration, () => {}).add(libraryUrl);

--- a/lib/src/migrators/module/scope.dart
+++ b/lib/src/migrators/module/scope.dart
@@ -21,8 +21,7 @@ class Scope {
   ///
   /// These are usually VariableDeclarations, but can also be Arguments from
   /// a CallableDeclaration.
-  final variables =
-      <String, MemberDeclaration<SassNode /*VariableDeclaration|Argument*/ >>{};
+  final variables = <String, MemberDeclaration>{};
 
   /// Mixins defined in this scope.
   final mixins = <String, MemberDeclaration<MixinRule>>{};

--- a/lib/src/migrators/namespace.dart
+++ b/lib/src/migrators/namespace.dart
@@ -170,7 +170,7 @@ class _NamespaceMigrationVisitor extends MigrationVisitor {
   @override
   void visitFunctionExpression(FunctionExpression node) {
     _addNamespaceSpan(node.namespace, node.span);
-    var name = node.name.asPlain;
+    var name = node.name;
     if (name == 'get-function') {
       var moduleArg = node.arguments.named['module'];
       if (node.arguments.positional.length == 3) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.5.1
+version: 1.5.2
 description: A tool for running migrations on Sass files
 author: Jennifer Thakar <jathak@google.com>
 homepage: https://github.com/sass/migrator
@@ -18,7 +18,7 @@ dependencies:
   node_interop: ^2.0.2
   node_io: ^2.1.0
   path: ^1.8.0
-  sass: ^1.32.11
+  sass: ^1.38.1
   source_span: ^1.8.1
   string_scanner: ^1.1.0
   term_glyph: ^1.2.0


### PR DESCRIPTION
This updates the migrator to be compatible with the recent changes to
`DynamicImport.url` and `FunctionExpression.name`, and also uses the new
`SassReference` and `SassDeclaration` interfaces.

For now, it's still importing the Sass AST from `dart-sass`'s `src`,
rather than from the new `sass_api`.