### PR TITLE
Remove a now unnecessary null assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.5.5-dev
+
 ## 1.5.4
 
 ### Module Migrator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 1.5.5-dev
+## 1.5.5
+
+* No user-visible changes.
 
 ## 1.5.4
 

--- a/lib/src/migrators/module.dart
+++ b/lib/src/migrators/module.dart
@@ -1321,7 +1321,7 @@ class _ModuleMigrationVisitor extends MigrationVisitor {
           prefix.length < identifier.length &&
           identifier.startsWith(prefix) &&
           Parser.isIdentifier(identifier.substring(prefix.length))),
-      (prefix) => prefix!.length);
+      (prefix) => prefix.length);
 
   /// Disallows `@use` after `@at-root` rules.
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.5.4
+version: 1.5.5-dev
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 
@@ -9,7 +9,7 @@ environment:
 dependencies:
   args: ^2.1.0
   charcode: ^1.2.0
-  collection: ^1.15.0
+  collection: ^1.16.0
   file: ^6.1.0
   glob: ^2.0.1
   js: ^0.6.3


### PR DESCRIPTION
In the latest version of `package:collection` the argument type for the
callback in `maxBy` was tightened since it has unnecessarily been marked
as nullable.

Remove the null assertion and bump the minimum version of `collection`.