### PR TITLE
Fix null pointer exception in references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.7.2
+
+### Module Migrator
+
+* Fixes a rare crash in certain cases involving reassignments of variables from
+  another module.
+
 ## 1.7.1
 
 * Eliminates invalid warnings when running `--migrate-deps` on a file that

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -638,9 +638,8 @@ class _ReferenceVisitor with RecursiveStatementVisitor, RecursiveAstVisitor {
     var declaration = _scopeForNamespace(namespace).findVariable(node.name);
     if (declaration != null && !_fromForwardRuleInCurrent(declaration)) {
       _variables[node] = declaration;
-      if (declaration.member is VariableDeclaration) {
-        _sources[node] = _declarationSources[declaration]!;
-      }
+      var source = _declarationSources[declaration];
+      if (source != null) _sources[node] = source;
     } else if (namespace == null) {
       _unresolvedReferences[node] = _scope;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 1.7.1
+version: 1.7.2
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 


### PR DESCRIPTION
I haven't been able to come up with a minimal reproduction of this (hence no test here), but this resolves an internal crash when depending on certain already-migrated-code that reassigns variables in another module.