### PR TITLE
Keep interpolation in var CSS function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.1
+
+### Calc Functions Interpolation Migrator
+
+* Add parentheses in place of interpolation when necessary to preserve the evaluation order.
+* Keep interpolation in `var()` CSS functions.
+
 ## 2.0.0
 
 * **Breaking change**: The `media-logic` migrator has been removed as the
@@ -7,11 +14,6 @@
   [media logic]: https://sass-lang.com/documentation/breaking-changes/media-logic/
 
 * Update to be compatible with the latest version of the Dart Sass AST.
-
-### Calc Functions Interpolation Migrator
-
-* Add parentheses in place of interpolation when necessary to preserve the
-  evaluation order.
 
 ### Division Migrator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 2.0.0
+version: 2.0.1
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 

--- a/test/migrators/calc_interpolation/calc_remove_interpolation.hrx
+++ b/test/migrators/calc_interpolation/calc_remove_interpolation.hrx
@@ -21,6 +21,9 @@ $d: 5;
 // CSS Custom properties keep interpolation
 .a { --test: calc(#{$b} + 1);}
 
+// var() nested
+.a { .b: calc(var(#{$b}) + #{$c + 2} + var(--a-#{$d}-b)); }
+
 <==> output/entrypoint.scss
 $b: 10;
 $c: 1;
@@ -43,3 +46,6 @@ $d: 5;
 
 // CSS Custom properties keep interpolation
 .a { --test: calc(#{$b} + 1);}
+
+// var() nested
+.a { .b: calc(var(#{$b}) + ($c + 2) + var(--a-#{$d}-b)); }


### PR DESCRIPTION
Bug fix: Keep interpolation within `var()` functions.