### PR TITLE
Fix operators regex to remove unnecessary parenthesis in SCSS variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2
+
+### Calc Functions Interpolation Migrator
+
+* Fix the interpretation of a dash in a variable name as a minus sign.
+
 ## 2.0.1
 
 ### Calc Functions Interpolation Migrator

--- a/lib/src/migrators/calc_interpolation.dart
+++ b/lib/src/migrators/calc_interpolation.dart
@@ -36,7 +36,7 @@ class _CalculationInterpolationVisitor extends MigrationVisitor {
   void visitFunctionExpression(FunctionExpression node) {
     const calcFunctions = ['calc', 'clamp', 'min', 'max'];
     final interpolation = RegExp(r'\#{\s*[^}]+\s*}');
-    final hasOperation = RegExp(r'[-+*/]+');
+    final hasOperation = RegExp(r'\s+[-+*/]+\s+');
     final isVarFunc = RegExp(
         r'var\(#{[a-zA-Z0-9#{$}-]+}\)|var\(\-\-[a-zA-Z0-9\$\#\{\}\-]+\)');
     if (calcFunctions.contains(node.name)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 2.0.1
+version: 2.0.2
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 

--- a/test/migrators/calc_interpolation/calc_remove_interpolation.hrx
+++ b/test/migrators/calc_interpolation/calc_remove_interpolation.hrx
@@ -1,4 +1,5 @@
 <==> input/entrypoint.scss
+$a-b: 5;
 $b: 10;
 $c: 1;
 $d: 5;
@@ -9,14 +10,14 @@ $d: 5;
 // More than one interpolations
 .a { 
     .b: calc($b - #{$c + 1} + #{$d}); 
-    .c: calc(100% - #{$table_title_height + 2px});
+    .c: calc(100% - #{$TABLE_TITLE + 2px});
 }
 
 // Nested
 .a { .b: calc(3 + max(#{$c, 2})); }
 
 // Nested and more interpolations
-.a { .b: calc(#{$b} + max(#{$c, 2})); }
+.a { .b: calc(#{$a-b} + max(#{$c, 2})); }
 
 // CSS Custom properties keep interpolation
 .a { --test: calc(#{$b} + 1);}
@@ -25,6 +26,7 @@ $d: 5;
 .a { .b: calc(var(#{$b}) + #{$c + 2} + var(--a-#{$d}-b)); }
 
 <==> output/entrypoint.scss
+$a-b: 5;
 $b: 10;
 $c: 1;
 $d: 5;
@@ -35,14 +37,14 @@ $d: 5;
 // More than one interpolations
 .a { 
     .b: calc($b - ($c + 1) + $d); 
-    .c: calc(100% - ($table-title-height + 2px));
+    .c: calc(100% - ($TABLE-TITLE + 2px));
 }
 
 // Nested
 .a { .b: calc(3 + max($c, 2)); }
 
 // Nested and more interpolations
-.a { .b: calc($b + max($c, 2)); }
+.a { .b: calc($a-b + max($c, 2)); }
 
 // CSS Custom properties keep interpolation
 .a { --test: calc(#{$b} + 1);}


### PR DESCRIPTION
`calc(#{$a-b})` was being migrated to `calc(($a-b))` because of the `-` less operator.