### PR TITLE
Fix null pointer errors in references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3
+
+### Module Migrator
+
+* Fixes some crashes due to null pointer errors.
+
 ## 2.0.2
 
 ### Calc Functions Interpolation Migrator

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -616,8 +616,9 @@ class _ReferenceVisitor extends ScopedAstVisitor {
     var declaration = _scopeForNamespace(namespace).findVariable(node.name);
     if (declaration != null && !_fromForwardRuleInCurrent(declaration)) {
       _variables[node] = declaration;
-      var source = _declarationSources[declaration];
-      if (source != null) _sources[node] = source;
+      if (_declarationSources[declaration] case var source?) {
+        _sources[node] = source;
+      }
     } else if (namespace == null) {
       _unresolvedReferences[node] = currentScope;
     }
@@ -645,7 +646,9 @@ class _ReferenceVisitor extends ScopedAstVisitor {
     var declaration = _scopeForNamespace(namespace).findMixin(node.name);
     if (declaration != null && !_fromForwardRuleInCurrent(declaration)) {
       _mixins[node] = declaration;
-      _sources[node] = _declarationSources[declaration]!;
+      if (_declarationSources[declaration] case var source?) {
+        _sources[node] = source;
+      }
     } else if (namespace == null) {
       _unresolvedReferences[node] = currentScope;
     }
@@ -673,7 +676,9 @@ class _ReferenceVisitor extends ScopedAstVisitor {
     var declaration = _scopeForNamespace(namespace).findFunction(node.name);
     if (declaration != null && !_fromForwardRuleInCurrent(declaration)) {
       _functions[node] = declaration;
-      _sources[node] = _declarationSources[declaration]!;
+      if (_declarationSources[declaration] case var source?) {
+        _sources[node] = source;
+      }
       return;
     } else if (namespace == null) {
       if (node.name == 'get-function') {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 2.0.2
+version: 2.0.3
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   js: ^0.6.3
   meta: ^1.3.0
   node_interop: ^2.0.2
-  node_io: ^2.2.0
+  node_io: ^2.3.0
   path: ^1.8.0
   sass_api: ^9.2.7
   source_span: ^1.8.1


### PR DESCRIPTION
Fixes #244 and an internal bug

Still can't figure out the actual root cause here, but this should fix the crashes for mixins and functions similar to how #236 fixed the crashes for for variables.