### PR TITLE
Don't migrate plain CSS min and max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.2.1
+
+### Module Migrator
+
+* Fix a bug where plain CSS `min()` and `max()` functions would incorrectly
+  be migrated to `math.min()` and `math.max()`.
+
 ## 2.2.0
 
 ### Module Migrator

--- a/lib/src/migrator.dart
+++ b/lib/src/migrator.dart
@@ -10,7 +10,6 @@ import 'package:meta/meta.dart';
 import 'package:path/path.dart' as p;
 import 'package:sass_api/sass_api.dart';
 import 'package:source_span/source_span.dart';
-import 'package:stack_trace/stack_trace.dart';
 
 import 'exception.dart';
 import 'io.dart';
@@ -58,10 +57,6 @@ abstract class Migrator extends Command<Map<Uri, String>> {
   Map<Uri, String> migrateFile(
       ImportCache importCache, Stylesheet stylesheet, Importer importer);
 
-  /// This is called whenever a deprecation warning is emitted during parsing.
-  @protected
-  void handleDeprecation(String message, FileSpan? span) {}
-
   /// Runs this migrator.
   ///
   /// Each entrypoint is migrated separately. If a stylesheet is migrated more
@@ -75,8 +70,7 @@ abstract class Migrator extends Command<Map<Uri, String>> {
     var importer = FilesystemImporter('.');
     var importCache = ImportCache(
         importers: [NodeModulesImporter()],
-        loadPaths: globalResults!['load-path'],
-        logger: _DeprecationLogger(this));
+        loadPaths: globalResults!['load-path']);
 
     var entrypoints = [
       for (var argument in argResults!.rest)
@@ -129,25 +123,6 @@ abstract class Migrator extends Command<Map<Uri, String>> {
         printStderr('  ${p.prettyUri(url)} '
             '@${p.prettyUri(context.sourceUrl)}:${context.start.line + 1}');
       });
-    }
-  }
-}
-
-/// A silent logger that calls [Migrator.handleDeprecation] when it receives a
-/// deprecation warning
-class _DeprecationLogger implements Logger {
-  final Migrator migrator;
-
-  _DeprecationLogger(this.migrator);
-
-  @override
-  void debug(String message, SourceSpan span) {}
-
-  @override
-  void warn(String message,
-      {FileSpan? span, Trace? trace, bool deprecation = false}) {
-    if (deprecation) {
-      migrator.handleDeprecation(message, span);
     }
   }
 }

--- a/lib/src/migrators/module/references.dart
+++ b/lib/src/migrators/module/references.dart
@@ -294,9 +294,9 @@ class _ReferenceVisitor extends ScopedAstVisitor {
   bool _isCssCompatibilityOverload(FunctionExpression node) {
     var argument = getOnlyArgument(node.arguments);
     switch (node.name) {
-      case 'grayscale':
-      case 'invert':
-      case 'opacity':
+      case 'min' || 'max':
+        return node.arguments.positional.every((arg) => arg.isCalculationSafe);
+      case 'grayscale' || 'invert' || 'opacity':
         return argument is NumberExpression;
       case 'saturate':
         return argument != null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: sass_migrator
-version: 2.2.0
+version: 2.2.1
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 
@@ -17,7 +17,7 @@ dependencies:
   node_interop: ^2.0.2
   node_io: ^2.3.0
   path: ^1.8.0
-  sass_api: ^12.0.0
+  sass_api: ^14.1.0
   source_span: ^1.8.1
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0

--- a/test/cli_dart_test.dart
+++ b/test/cli_dart_test.dart
@@ -178,7 +178,8 @@ void main() {
 
     test("an unknown argument", () async {
       var migrator = await runMigrator(["--asdf"]);
-      expect(migrator.stderr, emits('Could not find an option named "asdf".'));
+      expect(
+          migrator.stderr, emits('Could not find an option named "--asdf".'));
       expect(migrator.stderr,
           emitsThrough(contains('for more information about a command.')));
       await migrator.shouldExit(64);

--- a/test/migrators/module/built_in_functions/doesnt_namespace_css_overloads.hrx
+++ b/test/migrators/module/built_in_functions/doesnt_namespace_css_overloads.hrx
@@ -5,6 +5,8 @@ $c: opacity(25%);
 $d: saturate(0.5);
 $e: alpha(opacity=50);
 $f: alpha(g=h, i=j, k=l);
+$g: min(var(--test), 5px);
+$h: max(1 + 2 * 3, 3 / 4 - 5);
 
 <==> log.txt
 Nothing to migrate!

--- a/test/migrators/module/built_in_functions/namespacing.hrx
+++ b/test/migrators/module/built_in_functions/namespacing.hrx
@@ -3,6 +3,7 @@ $a: mix(red, blue);
 $b: str-length("hello");
 $c: scale-color(blue, $lightness: -10%);
 $d: call(get-function(mix), red, blue);
+$e: min(10 % 2, 4 + 3);
 
 @function fn($args...) {
   @return keywords($args);
@@ -10,12 +11,14 @@ $d: call(get-function(mix), red, blue);
 
 <==> output/entrypoint.scss
 @use "sass:color";
+@use "sass:math";
 @use "sass:meta";
 @use "sass:string";
 $a: color.mix(red, blue);
 $b: string.length("hello");
 $c: color.scale(blue, $lightness: -10%);
 $d: meta.call(meta.get-function(mix, $module: "color"), red, blue);
+$e: math.min(10 % 2, 4 + 3);
 
 @function fn($args...) {
   @return meta.keywords($args);


### PR DESCRIPTION
Fixes #262.

This also updates to be compatible with sass_api 14.x