### PR TITLE
Bump the sass_api version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with: {sdk: "${{ matrix.dart_channel }}"}
       - uses: sass/clone-linked-repo@v1
         with: {repo: sass/dart-sass, path: dart-sass}
-      - run: "dart pub add \"override:sass:{path: dart-sass}\""
+      - run: "dart pub add \"override:sass:{path: dart-sass}\" \"override:sass_api:{path: dart-sass/pkg/sass_api}\""
       - run: dart pub get
       - run: dart pub run grinder pkg-standalone-dev
       - name: Run tests
@@ -74,7 +74,7 @@ jobs:
         with: {sdk: "${{ matrix.dart_channel }}"}
       - uses: sass/clone-linked-repo@v1
         with: {repo: sass/dart-sass, path: dart-sass}
-      - run: "dart pub add \"override:sass:{path: dart-sass}\""
+      - run: "dart pub add \"override:sass:{path: dart-sass}\" \"override:sass_api:{path: dart-sass/pkg/sass_api}\""
       - run: dart pub get
       - uses: actions/setup-node@v2
         with: {node-version: "${{ matrix.node_version }}"}
@@ -92,7 +92,7 @@ jobs:
       - uses: dart-lang/setup-dart@v1
       - uses: sass/clone-linked-repo@v1
         with: {repo: sass/dart-sass, path: dart-sass}
-      - run: "dart pub add \"override:sass:{path: dart-sass}\""
+      - run: "dart pub add \"override:sass:{path: dart-sass}\" \"override:sass_api:{path: dart-sass/pkg/sass_api}\""
       - run: dart pub get
       - name: Analyze dart
         run: dart analyze --fatal-warnings --fatal-infos lib tool test

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: sass_migrator
-version: 2.5.0
+version: 2.5.1
 description: A tool for running migrations on Sass files
 homepage: https://github.com/sass/migrator
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
   args: ^2.1.0
@@ -17,7 +17,7 @@ dependencies:
   node_interop: ^2.0.2
   node_io: ^2.3.0
   path: ^1.8.0
-  sass_api: ^15.4.0
+  sass_api: ^17.0.0
   source_span: ^1.8.1
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0
@@ -31,6 +31,7 @@ dev_dependencies:
   http: ^1.1.2
   node_preamble: ^2.0.0
   pub_semver: ^2.0.0
+  pubspec_parse: ^1.5.0
   test: ^1.17.1
   test_descriptor: ^2.0.0
   test_process: ^2.0.0

--- a/test/dependency_test.dart
+++ b/test/dependency_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2025 Google LLC
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:test/test.dart';
+import 'package:pubspec_parse/pubspec_parse.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  test("declares a compatible dependency for sass_api", () {
+    var migratorPubspec = Pubspec.parse(File("pubspec.yaml").readAsStringSync(),
+        sourceUrl: p.toUri("pubspec.yaml"));
+    var sassApiPubspecPath = p.normalize(p.join(
+        p.fromUri(
+            Isolate.resolvePackageUriSync(Uri.parse("package:sass_api/."))),
+        "../pubspec.yaml"));
+    var sassApiPubspec = Pubspec.parse(
+        File(sassApiPubspecPath).readAsStringSync(),
+        sourceUrl: p.toUri(sassApiPubspecPath));
+
+    switch (migratorPubspec.dependencies["sass_api"]) {
+      case HostedDependency dep:
+        if (!dep.version.allows(sassApiPubspec.version!)) {
+          fail("sass_api dependency $dep doesn't include actual sass_api "
+              "version ${sassApiPubspec.version!}");
+        }
+
+      case var dep?:
+        fail("Expected a hosted dependency on sass_api, was $dep");
+
+      case null:
+        fail("This package doesn't seem to have a dependency on sass_api");
+    }
+  });
+}


### PR DESCRIPTION
This also adds a test to ensure that this doesn't get out-of-date
relative to the version we test against, and updates the CI
configuration to use the sass_api package that matches the sass
package.

See #287