### PR TITLE
Work around Dart 3.13 breaking node_io

### DIFF
--- a/lib/src/io.dart
+++ b/lib/src/io.dart
@@ -4,9 +4,4 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
-// These libraries don't expose *exactly* the same API, but they overlap in all
-// the cases we care about.
-export 'dart:io' if (dart.library.js) 'package:node_io/node_io.dart';
-
-// For cases that aren't covered by `node_io`.
 export 'io/vm.dart' if (dart.library.js) 'io/node.dart';

--- a/lib/src/io/node.dart
+++ b/lib/src/io/node.dart
@@ -7,7 +7,10 @@
 import 'package:file/file.dart';
 import 'package:js/js.dart';
 import 'package:node_interop/node.dart';
-import 'package:node_io/node_io.dart';
+import 'package:node_io/src/file_system.dart';
+
+export 'package:node_io/src/directory.dart';
+export 'package:node_io/src/file.dart';
 
 // Node seems to support ANSI escapes on all terminals.
 //
@@ -18,4 +21,9 @@ external bool get supportsAnsiEscapes;
 
 void printStderr(Object message) => process.stderr.write("$message\n");
 
-FileSystem get fileSystem => nodeFileSystem;
+int get exitCode => process.exitCode;
+void set exitCode(int code) {
+  process.exitCode = code;
+}
+
+final FileSystem fileSystem = NodeFileSystem();

--- a/lib/src/io/vm.dart
+++ b/lib/src/io/vm.dart
@@ -4,6 +4,8 @@
 // license that can be found in the LICENSE file or at
 // https://opensource.org/licenses/MIT.
 
+export 'dart:io' show File, Directory, exitCode;
+
 import 'dart:io';
 
 import 'package:file/file.dart';


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/63216 broke a part of node_io that we don't use, so this works around the issue by importing only the individual pieces of node_io that we need.